### PR TITLE
remove redundant should

### DIFF
--- a/src/app/components/home/tests/home.component.spec.ts
+++ b/src/app/components/home/tests/home.component.spec.ts
@@ -32,7 +32,7 @@ describe('HomeComponent', () => {
     homeHarness = await TestbedHarnessEnvironment.harnessForFixture(fixture, HomeHarness)
   })
 
-  it('should display welcome message', async () => {
+  it('display welcome message', async () => {
     expect(await homeHarness.controlPresent('welcomeMessage')).toBe(true)
   })
 })

--- a/src/app/components/login/test/login.component.spec.ts
+++ b/src/app/components/login/test/login.component.spec.ts
@@ -69,7 +69,7 @@ describe('LoginComponent', () => {
     router = TestBed.inject(Router)
   })
 
-  it('should enable/disable login button based on form validity', async () => {
+  it('enable/disable login button based on form validity', async () => {
     // initial state
     // invalid form: login missing, password missing
     expect(await loginHarness.buttonEnabled('loginButton')).toBe(false)
@@ -95,7 +95,7 @@ describe('LoginComponent', () => {
     expect(await loginHarness.buttonEnabled('loginButton')).toBe(false)
   })
 
-  it('should display/hide error message based on login validity', async () => {
+  it('display/hide error message based on login validity', async () => {
     // initial state: no validation done
     expect(await loginHarness.controlPresent('loginErrorEmpty')).toBe(false)
 
@@ -114,7 +114,7 @@ describe('LoginComponent', () => {
     expect(await loginHarness.controlPresent('loginErrorEmpty')).toBe(true)
   })
 
-  it('should display/hide error message based on password validity', async () => {
+  it('display/hide error message based on password validity', async () => {
     // initial state: no validation done
     expect(await loginHarness.controlPresent('passwordErrorEmpty')).toBe(false)
 
@@ -133,7 +133,7 @@ describe('LoginComponent', () => {
     expect(await loginHarness.controlPresent('passwordErrorEmpty')).toBe(false)
   })
 
-  it('should display error message in case of invalid credentials', async () => {
+  it('display error message in case of invalid credentials', async () => {
     expect(await loginHarness.controlPresent('incorrectCreds')).toBe(false)
 
     await loginHarness.enterInputValue('loginInput', `${VALID_CREDS.login}_invalid`)
@@ -142,7 +142,7 @@ describe('LoginComponent', () => {
     expect(await loginHarness.controlPresent('incorrectCreds')).toBe(true)
   })
 
-  it('should navigate to home on successful login', async () => {
+  it('navigate to home on successful login', async () => {
     const navigateSpy = spyOn<Router, 'navigate'>(router, 'navigate')
 
     await loginHarness.enterInputValue('loginInput', VALID_CREDS.login)

--- a/src/app/components/not-found/tests/not-found.component.spec.ts
+++ b/src/app/components/not-found/tests/not-found.component.spec.ts
@@ -41,11 +41,11 @@ describe('NotFoundComponent', () => {
     router = TestBed.inject(Router)
   })
 
-  it('should display "not found" message', async () => {
+  it('display "not found" message', async () => {
     expect(await notFoundHarness.controlPresent('notFoundMessage')).toBe(true)
   })
 
-  it('should navigate to home page on link click', async () => {
+  it('navigate to home page on link click', async () => {
     const navigateByUrlSpy = spyOn<Router, 'navigateByUrl'>(router, 'navigateByUrl')
 
     await notFoundHarness.clickLink('navToHomeLink')

--- a/src/app/tests/app.component.spec.ts
+++ b/src/app/tests/app.component.spec.ts
@@ -59,18 +59,18 @@ describe('AppComponent', () => {
     router = TestBed.inject(Router)
   })
 
-  it('should display translated welcome message', async () => {
+  it('display translated welcome message', async () => {
     expect(await appHarness.controlText('welcomeMessage')).toBe('Hello, contracts-angular component en')
   })
 
-  it('should navigate to login on successful logout', async () => {
+  it('navigate to login on successful logout', async () => {
     const navigateSpy = spyOn<Router, 'navigate'>(router, 'navigate')
 
     await appHarness.clickButton('logoutButton')
     expect(navigateSpy).toHaveBeenCalledWith(['/login'])
   })
 
-  it('should display welcome message and logout button only to authenticated user', async () => {
+  it('display welcome message and logout button only to authenticated user', async () => {
     expect(await appHarness.controlPresent('welcomeMessage')).toBe(true)
     expect(await appHarness.controlPresent('logoutButton')).toBe(true)
 


### PR DESCRIPTION
'should' doesn't add info to test messages, but takes place;
'should' doesn't work in all the cases;
'it' is not used by reporters anyway;