### PR TITLE
ft service handles page reload

### DIFF
--- a/src/app/services/auth/auth.service.spec.ts
+++ b/src/app/services/auth/auth.service.spec.ts
@@ -28,7 +28,10 @@ describe('AuthService', () => {
 
   beforeEach(() => {
     localStorage.clear()
-    featureToggleServiceMock = jasmine.createSpyObj<FeatureToggleService>('featureToggleService', ['init'])
+    featureToggleServiceMock = jasmine.createSpyObj<FeatureToggleService>('featureToggleService', [
+      'init',
+      'cleanup'
+    ])
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
       providers: [{
@@ -70,6 +73,14 @@ describe('AuthService', () => {
 
     expect(testRequest.request.method).toBe('POST')
     expect(testRequest.request.body).toEqual({})
+  })
+
+  it('logout cleans up feature toggle service', () => {
+    service.logout().subscribe()
+    const testRequest = httpTestingController.expectOne('/api/auth/logout')
+
+    testRequest.flush(null)
+    expect(featureToggleServiceMock.cleanup).toHaveBeenCalledWith()
   })
 
   it('isAuth emits proper values on login/logout', () => {
@@ -127,7 +138,7 @@ describe('AuthService - creation', () => {
     localStorage.clear()
   })
 
-  it('isAuth initializes to true if local storage has auth token', () => {
+  it('service is initialized properly if local storage has auth token', () => {
     localStorage.setItem(AUTH_TOKEN_LOCAL_STORAGE_KEY, 'token')
 
     TestBed.configureTestingModule({
@@ -141,9 +152,10 @@ describe('AuthService - creation', () => {
 
     // initial value
     expect(isAuthValues.pop()).toBe(true)
+    expect(service.getAuthToken()).toBe('token')
   })
 
-  it('isAuth initializes to false if local storage does not have auth token', () => {
+  it('service is not initialized if local storage does not have auth token', () => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule]
     })
@@ -155,5 +167,6 @@ describe('AuthService - creation', () => {
 
     // initial value
     expect(isAuthValues.pop()).toBe(false)
+    expect(service.getAuthToken()).toBeNull()
   })
 })

--- a/src/app/services/auth/auth.service.ts
+++ b/src/app/services/auth/auth.service.ts
@@ -50,6 +50,7 @@ export class AuthService {
     return this.http.post<void>('/api/auth/logout', {}).pipe(
       tap(() => {
         localStorage.removeItem(this.AUTH_TOKEN_LOCAL_STORAGE_KEY)
+        this.ft.cleanup()
         this.isAuthSubject.next(!!this.getAuthToken())
       })
     )

--- a/src/app/services/features/feature-toggle.service.ts
+++ b/src/app/services/features/feature-toggle.service.ts
@@ -6,20 +6,32 @@ import {
   providedIn: 'root'
 })
 export class FeatureToggleService {
-  private activeFeatures: string[] = []
-  private initCompleted: boolean = false
+  private ACTIVE_FEATURES_LOCAL_STORAGE_KEY = 'activeFeaturesContractsManagement'
+  private initCompleted: boolean = !!this.getActiveFeatures().length
 
-  public init(activeFeatures: string[]): void {
-    if (!this.initCompleted) {
-      this.activeFeatures = activeFeatures
-      this.initCompleted = true
+  private getActiveFeatures(): string[] {
+    const activeFeatures: string | null = localStorage.getItem(this.ACTIVE_FEATURES_LOCAL_STORAGE_KEY)
+    if (activeFeatures) {
+      return JSON.parse(activeFeatures)
     }
     else {
-      throw new Error('Feature toggle service initialization already completed.')
+      return []
     }
   }
 
+  public init(activeFeatures: string[]): void {
+    if (!this.initCompleted) {
+      localStorage.setItem(this.ACTIVE_FEATURES_LOCAL_STORAGE_KEY, JSON.stringify(activeFeatures))
+      this.initCompleted = true
+    }
+  }
+
+  public cleanup(): void {
+    localStorage.removeItem(this.ACTIVE_FEATURES_LOCAL_STORAGE_KEY)
+    this.initCompleted = false
+  }
+
   public isActive(feature: string): boolean {
-    return this.activeFeatures.includes(feature)
+    return this.getActiveFeatures().includes(feature)
   }
 }

--- a/src/app/tests/interceptors.spec.ts
+++ b/src/app/tests/interceptors.spec.ts
@@ -43,7 +43,7 @@ describe('Interceptors', () => {
     httpTestingController.verify()
   })
 
-  it('auth headers are added', () => {
+  it('auth interceptor adds auth headers', () => {
     const url = '/mockendpoint'
 
     httpClient.get(url).subscribe()


### PR DESCRIPTION
since ft service depends on login, manage it in login/logout; consider local storage during ft service initialization; adjust tests;
adjust test names;