### PR TITLE
use initComponent pattern

### DIFF
--- a/src/app/components/contracts/tests/contracts.component.spec.ts
+++ b/src/app/components/contracts/tests/contracts.component.spec.ts
@@ -32,9 +32,10 @@ import {
 describe('ContractsComponent', () => {
   let contractServiceMock: jasmine.SpyObj<ContractService>
   let messageBoxServiceMock: jasmine.SpyObj<MessageBoxService>
-  let contractsHarness: ContractsHarness
 
-  async function initComponent(contracts?: Contract[]): Promise<ContractsHarness> {
+  async function initComponent(contracts?: Contract[]): Promise<{
+    contractsHarness: ContractsHarness
+  }> {
     if (contracts) {
       contractServiceMock.getContracts.and.returnValue(of(contracts))
     }
@@ -62,8 +63,10 @@ describe('ContractsComponent', () => {
     }).compileComponents()
 
     const fixture = TestBed.createComponent(ContractsComponent)
-    contractsHarness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ContractsHarness)
-    return contractsHarness
+    const contractsHarness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ContractsHarness)
+    return {
+      contractsHarness
+    }
   }
 
   beforeEach(async () => {
@@ -84,7 +87,9 @@ describe('ContractsComponent', () => {
         conditions: 'test contract b'
       }
     ]
-    await initComponent(CONTRACTS)
+    const {
+      contractsHarness
+    } = await initComponent(CONTRACTS)
 
     expect(await contractsHarness.elementChildCount('contractList')).toBe(CONTRACTS.length)
     expect(await contractsHarness.elementVisible('noContractsMessage')).toBe(false)
@@ -95,7 +100,9 @@ describe('ContractsComponent', () => {
   })
 
   it('display no contract message if there are no contracts', async () => {
-    await initComponent([])
+    const {
+      contractsHarness: contractsHarness
+    } = await initComponent([])
 
     expect(await contractsHarness.elementChildCount('contractList')).toBe(0)
     expect(await contractsHarness.elementVisible('noContractsMessage')).toBe(true)

--- a/src/app/components/home/tests/home.component.spec.ts
+++ b/src/app/components/home/tests/home.component.spec.ts
@@ -17,9 +17,9 @@ import {
 } from '@angular/cdk/testing/testbed'
 
 describe('HomeComponent', () => {
-  let homeHarness: HomeHarness
-
-  beforeEach(async () => {
+  async function initComponent(): Promise<{
+    homeHarness: HomeHarness
+  }> {
     await TestBed.configureTestingModule({
       imports: [
         HomeComponent,
@@ -29,10 +29,17 @@ describe('HomeComponent', () => {
     }).compileComponents()
 
     const fixture = TestBed.createComponent(HomeComponent)
-    homeHarness = await TestbedHarnessEnvironment.harnessForFixture(fixture, HomeHarness)
-  })
+    const homeHarness = await TestbedHarnessEnvironment.harnessForFixture(fixture, HomeHarness)
+    return {
+      homeHarness
+    }
+  }
 
   it('display welcome message', async () => {
+    const {
+      homeHarness
+    } = await initComponent()
+
     expect(await homeHarness.elementVisible('welcomeMessage')).toBe(true)
   })
 })

--- a/src/app/components/not-found/tests/not-found.component.spec.ts
+++ b/src/app/components/not-found/tests/not-found.component.spec.ts
@@ -23,10 +23,10 @@ import {
 } from '@angular/router'
 
 describe('NotFoundComponent', () => {
-  let notFoundHarness: NotFoundHarness
-  let router: Router
-
-  beforeEach(async () => {
+  async function initComponent(): Promise<{
+    notFoundHarness: NotFoundHarness
+    router: Router
+  }> {
     await TestBed.configureTestingModule({
       imports: [
         NotFoundComponent,
@@ -36,16 +36,28 @@ describe('NotFoundComponent', () => {
       providers: []
     }).compileComponents()
 
+    const router = TestBed.inject(Router)
+
     const fixture = TestBed.createComponent(NotFoundComponent)
-    notFoundHarness = await TestbedHarnessEnvironment.harnessForFixture(fixture, NotFoundHarness)
-    router = TestBed.inject(Router)
-  })
+    const notFoundHarness = await TestbedHarnessEnvironment.harnessForFixture(fixture, NotFoundHarness)
+    return {
+      notFoundHarness,
+      router
+    }
+  }
 
   it('display "not found" message', async () => {
+    const {
+      notFoundHarness
+    } = await initComponent()
+
     expect(await notFoundHarness.elementVisible('notFoundMessage')).toBe(true)
   })
 
   it('navigate to home page on link click', async () => {
+    const {
+      notFoundHarness, router
+    } = await initComponent()
     const navigateByUrlSpy = spyOn<Router, 'navigateByUrl'>(router, 'navigateByUrl')
 
     await notFoundHarness.clickLink('navToHomeLink')

--- a/src/app/tests/foundation/tests/test.component.spec.ts
+++ b/src/app/tests/foundation/tests/test.component.spec.ts
@@ -121,14 +121,6 @@ describe('Base harness', () => {
     await expectAsync(baseHarness.elementChildCount('div-child-count-grandchild-present-non-existent')).toBeRejected()
   })
 
-  it('elementChildCount', async () => {
-    await expectAsync(baseHarness.elementChildCount('div-child-count-no-grandchild-present')).toBeResolvedTo(2)
-    await expectAsync(baseHarness.elementChildCount('div-child-count-grandchild-present')).toBeResolvedTo(2)
-
-    await expectAsync(baseHarness.elementChildCount('div-child-count-no-grandchild-present-non-existent')).toBeRejected()
-    await expectAsync(baseHarness.elementChildCount('div-child-count-grandchild-present-non-existent')).toBeRejected()
-  })
-
   it('enterValue - updateOn: change', async () => {
     let formValuesOnChange: string[] = []
     testComponent.formControlUpdateOnChange.valueChanges.subscribe((value: string) => {


### PR DESCRIPTION
1. Define initComponent function that returns named harness (allows to use shorthand destructuring) and router (if needed); Keep in mind that INJET could only be called after configureTestingModule so injections should be done either in initComponent or after its call in a test;
2. Initialize service spy objects in Jasmine beforeEach to make sure Jasmine handles thier lifecycle;
3. In test: override/define spies, THEN call initComponent to finish GIVEN stage of the test;

initComponent allows more flexibility for component unit testing (different returned datasets, FTs, etc.)