### PR TITLE
change contract service ft protection

### DIFF
--- a/src/app/services/contracts/contract.service.ts
+++ b/src/app/services/contracts/contract.service.ts
@@ -23,21 +23,20 @@ export class ContractService {
   public constructor(
     private ft: FeatureToggleService,
     private http: HttpClient
-  ) {
-    if (!this.ft.isActive('FT_Contracts')) {
-      throw new Error('Feature is inactive')
-    }
-  }
+  ) {}
 
   public getContracts(): Observable<Contract[]> {
+    this.ft.throwIfInactive('FT_Contracts')
     return this.http.get<Contract[]>(this.endpointPath)
   }
 
   public deleteContract(id: string): Observable<void> {
+    this.ft.throwIfInactive('FT_Contracts')
     return this.http.delete<void>(`${this.endpointPath}/${id}`)
   }
 
   public createContract(contract: Omit<Contract, 'id'>): Observable<string> {
+    this.ft.throwIfInactive('FT_Contracts')
     return this.http.post<{ id: string }>(`${this.endpointPath}`, contract).pipe(
       map(x => x.id)
     )

--- a/src/app/services/features/feature-toggle.service.spec.ts
+++ b/src/app/services/features/feature-toggle.service.spec.ts
@@ -58,6 +58,20 @@ describe('FeatureToggleService', () => {
     expect(service.isActive('FT_A')).toBe(false)
     expect(service.isActive('FT_B')).toBe(true)
   })
+
+  it('isActive and throw if inactive', () => {
+    const isActiveSpy = spyOn<FeatureToggleService, 'isActive'>(service, 'isActive')
+    isActiveSpy.withArgs('FT_A').and.returnValue(false)
+    isActiveSpy.withArgs('FT_B').and.returnValue(true)
+
+    expect(() => {
+      service.throwIfInactive('FT_A')
+    }).toThrowError('feature inactive')
+
+    expect(() => {
+      service.throwIfInactive('FT_B')
+    }).not.toThrow()
+  })
 })
 
 describe('FeatureToggleService - creation', () => {

--- a/src/app/services/features/feature-toggle.service.ts
+++ b/src/app/services/features/feature-toggle.service.ts
@@ -38,7 +38,15 @@ export class FeatureToggleService {
     this.activeFeatures = []
   }
 
+  // useful for components and templates
   public isActive(feature: string): boolean {
     return this.activeFeatures.includes(feature)
+  }
+
+  // useful for services
+  public throwIfInactive(feature: string): void {
+    if (!this.isActive(feature)) {
+      throw new Error('feature inactive')
+    }
   }
 }


### PR DESCRIPTION
throwing errors in dependency contract is not a good idea since we don't control the moment the dependency is initialized;
it is better to protect individual methods instead;