### PR TITLE
change navigation testing strategy

### DIFF
--- a/src/app/components/contract/tests/contract.component.spec.ts
+++ b/src/app/components/contract/tests/contract.component.spec.ts
@@ -12,9 +12,6 @@ import {
   RouterTestingModule
 } from '@angular/router/testing'
 import {
-  Router
-} from '@angular/router'
-import {
   ContractComponent
 } from '../contract.component'
 import {
@@ -41,7 +38,6 @@ describe('ContractComponent', () => {
 
   async function initComponent(): Promise<{
     contractHarness: ContractHarness
-    router: Router
   }> {
     await TestBed.configureTestingModule({
       imports: [
@@ -65,13 +61,10 @@ describe('ContractComponent', () => {
       ]
     }).compileComponents()
 
-    const router = TestBed.inject(Router)
-
     const fixture = TestBed.createComponent(ContractComponent)
     const contractHarness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ContractHarness)
     return {
-      contractHarness,
-      router
+      contractHarness
     }
   }
 

--- a/src/app/components/contracts/tests/contracts.component.spec.ts
+++ b/src/app/components/contracts/tests/contracts.component.spec.ts
@@ -29,11 +29,14 @@ import {
   BackendErrorHandlerService
 } from '../../../services/backend-error-handler/backend-error-handler.service'
 import {
-  Router
-} from '@angular/router'
-import {
   RouterTestingModule
 } from '@angular/router/testing'
+import {
+  TestComponent
+} from '../../../tests/utils'
+import {
+  Location
+} from '@angular/common'
 
 describe('ContractsComponent', () => {
   let contractServiceMock: jasmine.SpyObj<ContractService>
@@ -53,7 +56,6 @@ describe('ContractsComponent', () => {
 
   async function initComponent(contracts?: Contract[]): Promise<{
     contractsHarness: ContractsHarness
-    router: Router
   }> {
     if (contracts) {
       contractServiceMock.getContracts.and.returnValue(of(contracts))
@@ -68,7 +70,10 @@ describe('ContractsComponent', () => {
       imports: [
         ContractsComponent,
         getTranslocoTestingModule(ContractsComponent, en),
-        RouterTestingModule.withRoutes([])
+        RouterTestingModule.withRoutes([{
+          path: 'contract',
+          component: TestComponent
+        }])
       ],
       providers: [
         {
@@ -84,10 +89,8 @@ describe('ContractsComponent', () => {
 
     const fixture = TestBed.createComponent(ContractsComponent)
     const contractsHarness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ContractsHarness)
-    const router = TestBed.inject(Router)
     return {
-      contractsHarness,
-      router
+      contractsHarness
     }
   }
 
@@ -185,27 +188,22 @@ describe('ContractsComponent', () => {
 
   it('contract add', async () => {
     const {
-      contractsHarness, router
+      contractsHarness
     } = await initComponent(CONTRACTS)
-    const navigateSpy = spyOn<Router, 'navigate'>(router, 'navigate')
 
     await contractsHarness.clickButton('addContractButton')
-    expect(navigateSpy).toHaveBeenCalledWith(['/contract'])
+    const location = TestBed.inject(Location)
+    expect(location.path()).toBe('/contract')
   })
 
   it('contract edit', async () => {
     const {
-      contractsHarness, router
+      contractsHarness
     } = await initComponent(CONTRACTS)
-    const navigateSpy = spyOn<Router, 'navigate'>(router, 'navigate')
     const contractToEdit = CONTRACTS[1]
 
     await contractsHarness.inElement(`contract-${contractToEdit.id}`).clickButton('editContract')
-    expect(navigateSpy).toHaveBeenCalledWith(['/contract'],
-      jasmine.objectContaining({
-        queryParams: {
-          contractId: contractToEdit.id
-        }
-      }))
+    const location = TestBed.inject(Location)
+    expect(location.path()).toBe(`/contract?contractId=${contractToEdit.id}`)
   })
 })

--- a/src/app/components/home/tests/home.component.spec.ts
+++ b/src/app/components/home/tests/home.component.spec.ts
@@ -22,21 +22,26 @@ import {
   RouterTestingModule
 } from '@angular/router/testing'
 import {
-  Router
-} from '@angular/router'
+  Location
+} from '@angular/common'
+import {
+  TestComponent
+} from '../../../tests/utils'
 
 describe('HomeComponent', () => {
   let featureToggleServiceMock: jasmine.SpyObj<FeatureToggleService>
 
   async function initComponent(): Promise<{
     homeHarness: HomeHarness
-    router: Router
   }> {
     await TestBed.configureTestingModule({
       imports: [
         HomeComponent,
         getTranslocoTestingModule(HomeComponent, en),
-        RouterTestingModule.withRoutes([])
+        RouterTestingModule.withRoutes([{
+          path: 'contracts',
+          component: TestComponent
+        }])
       ],
       providers: [{
         provide: FeatureToggleService,
@@ -46,10 +51,8 @@ describe('HomeComponent', () => {
 
     const fixture = TestBed.createComponent(HomeComponent)
     const homeHarness = await TestbedHarnessEnvironment.harnessForFixture(fixture, HomeHarness)
-    const router = TestBed.inject(Router)
     return {
-      homeHarness,
-      router
+      homeHarness
     }
   }
 
@@ -77,12 +80,12 @@ describe('HomeComponent', () => {
   it('FT_Contracts ON - navigate to home page on link click', async () => {
     featureToggleServiceMock.isActive.withArgs('FT_Contracts').and.returnValue(true)
     const {
-      homeHarness, router
+      homeHarness
     } = await initComponent()
-    const navigateByUrlSpy = spyOn<Router, 'navigateByUrl'>(router, 'navigateByUrl')
 
     await homeHarness.clickLink('navToContractsLink')
-    expect(navigateByUrlSpy).toHaveBeenCalledWith(router.createUrlTree(['/contracts']), jasmine.anything())
+    const location = TestBed.inject(Location)
+    expect(location.path()).toBe('/contracts')
   })
 
   it('FT_Contracts OFF - hide link to contracts', async () => {

--- a/src/app/components/login/test/login.component.spec.ts
+++ b/src/app/components/login/test/login.component.spec.ts
@@ -29,11 +29,14 @@ import {
   RouterTestingModule
 } from '@angular/router/testing'
 import {
-  Router
-} from '@angular/router'
-import {
   BackendErrorHandlerService
 } from '../../../services/backend-error-handler/backend-error-handler.service'
+import {
+  TestComponent
+} from '../../../tests/utils'
+import {
+  Location
+} from '@angular/common'
 
 describe('LoginComponent', () => {
   let authServiceMock: jasmine.SpyObj<AuthService>
@@ -45,13 +48,15 @@ describe('LoginComponent', () => {
 
   async function initComponent(): Promise<{
     loginHarness: LoginHarness
-    router: Router
   }> {
     await TestBed.configureTestingModule({
       imports: [
         LoginComponent,
         getTranslocoTestingModule(LoginComponent, en),
-        RouterTestingModule.withRoutes([])
+        RouterTestingModule.withRoutes([{
+          path: 'home',
+          component: TestComponent
+        }])
       ],
       providers: [
         {
@@ -65,13 +70,10 @@ describe('LoginComponent', () => {
       ]
     }).compileComponents()
 
-    const router = TestBed.inject(Router)
-
     const fixture = TestBed.createComponent(LoginComponent)
     const loginHarness = await TestbedHarnessEnvironment.harnessForFixture(fixture, LoginHarness)
     return {
-      loginHarness,
-      router
+      loginHarness
     }
   }
 
@@ -182,14 +184,14 @@ describe('LoginComponent', () => {
 
   it('navigate to home on successful login', async () => {
     const {
-      loginHarness, router
+      loginHarness
     } = await initComponent()
-    const navigateSpy = spyOn<Router, 'navigate'>(router, 'navigate')
 
     await loginHarness.enterValue('loginInput', VALID_CREDS.login)
     await loginHarness.enterValue('passwordInput', VALID_CREDS.password)
     await loginHarness.clickButton('loginButton')
-    expect(navigateSpy).toHaveBeenCalledWith(['/home'])
+    const location = TestBed.inject(Location)
+    expect(location.path()).toBe('/home')
   })
 
   it('handle backend error during login', async () => {

--- a/src/app/components/not-found/tests/not-found.component.spec.ts
+++ b/src/app/components/not-found/tests/not-found.component.spec.ts
@@ -18,14 +18,10 @@ import {
 import {
   RouterTestingModule
 } from '@angular/router/testing'
-import {
-  Router
-} from '@angular/router'
 
 describe('NotFoundComponent', () => {
   async function initComponent(): Promise<{
     notFoundHarness: NotFoundHarness
-    router: Router
   }> {
     await TestBed.configureTestingModule({
       imports: [
@@ -36,13 +32,10 @@ describe('NotFoundComponent', () => {
       providers: []
     }).compileComponents()
 
-    const router = TestBed.inject(Router)
-
     const fixture = TestBed.createComponent(NotFoundComponent)
     const notFoundHarness = await TestbedHarnessEnvironment.harnessForFixture(fixture, NotFoundHarness)
     return {
-      notFoundHarness,
-      router
+      notFoundHarness
     }
   }
 

--- a/src/app/guards/feature.can-match.guard.spec.ts
+++ b/src/app/guards/feature.can-match.guard.spec.ts
@@ -2,10 +2,6 @@ import {
   TestBed
 } from '@angular/core/testing'
 import {
-  Router
-} from '@angular/router'
-
-import {
   FeatureToggleService
 } from '../services/features/feature-toggle.service'
 import {
@@ -18,11 +14,14 @@ import {
 import {
   TestComponent
 } from '../tests/utils'
+import {
+  Location
+} from '@angular/common'
 
 describe('featureCanMatchGuard', () => {
   let featureToggleServiceMock: jasmine.SpyObj<FeatureToggleService>
   let routerHarness: RouterTestingHarness
-  let router: Router
+  let location: Location
 
   beforeEach(async () => {
     featureToggleServiceMock = jasmine.createSpyObj<FeatureToggleService>('featureToggleService', ['isActive'])
@@ -42,7 +41,7 @@ describe('featureCanMatchGuard', () => {
     }).compileComponents()
 
     routerHarness = await RouterTestingHarness.create()
-    router = TestBed.inject(Router)
+    location = TestBed.inject(Location)
   })
 
   it('both features inactive - cannot match the route', async () => {
@@ -64,6 +63,6 @@ describe('featureCanMatchGuard', () => {
     featureToggleServiceMock.isActive.withArgs('FT_Feature_B').and.returnValue(true)
 
     await routerHarness.navigateByUrl('/routeAB')
-    expect(router.url).toBe('/routeAB')
+    expect(location.path()).toBe('/routeAB')
   })
 })

--- a/src/app/services/navigation-back/navigation-back.service.spec.ts
+++ b/src/app/services/navigation-back/navigation-back.service.spec.ts
@@ -13,12 +13,12 @@ import {
   TestComponent
 } from '../../tests/utils'
 import {
-  Router
-} from '@angular/router'
+  Location
+} from '@angular/common'
 
 describe('NavigationBackService', () => {
   let service: NavigationBackService
-  let router: Router
+  let location: Location
   let routerHarness: RouterTestingHarness
 
   beforeEach(async () => {
@@ -47,7 +47,7 @@ describe('NavigationBackService', () => {
         }
       ])]
     })
-    router = TestBed.inject(Router)
+    location = TestBed.inject(Location)
     routerHarness = await RouterTestingHarness.create()
     service = TestBed.inject(NavigationBackService)
   })
@@ -58,12 +58,12 @@ describe('NavigationBackService', () => {
     await routerHarness.navigateByUrl('/route_b')
 
     await service.back()
-    expect(router.url).toBe('/route_a')
+    expect(location.path()).toBe('/route_a')
 
     await service.back()
-    expect(router.url).toBe('/base')
+    expect(location.path()).toBe('/base')
 
     await service.back()
-    expect(router.url).toBe('/home')
+    expect(location.path()).toBe('/home')
   })
 })

--- a/src/app/tests/app.component.spec.ts
+++ b/src/app/tests/app.component.spec.ts
@@ -34,6 +34,9 @@ import {
 import {
   TestComponent
 } from './utils'
+import {
+  Location
+} from '@angular/common'
 
 describe('AppComponent', () => {
   let isAuthMock: BehaviorSubject<boolean>
@@ -42,7 +45,6 @@ describe('AppComponent', () => {
 
   async function initComponent(): Promise<{
     appHarness: AppHarness
-    router: Router
   }> {
     await TestBed.configureTestingModule({
       imports: [
@@ -60,6 +62,10 @@ describe('AppComponent', () => {
           {
             path: 'home/subhome',
             component: TestComponent
+          },
+          {
+            path: 'login',
+            component: TestComponent
           }
         ])
       ],
@@ -75,13 +81,10 @@ describe('AppComponent', () => {
       ]
     }).compileComponents()
 
-    const router = TestBed.inject(Router)
-
     const fixture = TestBed.createComponent(AppComponent)
     const appHarness = await TestbedHarnessEnvironment.harnessForFixture(fixture, AppHarness)
     return {
-      appHarness,
-      router
+      appHarness
     }
   }
 
@@ -107,12 +110,12 @@ describe('AppComponent', () => {
 
   it('navigate to login on successful logout', async () => {
     const {
-      appHarness, router
+      appHarness
     } = await initComponent()
-    const navigateSpy = spyOn<Router, 'navigate'>(router, 'navigate')
 
     await appHarness.clickButton('logoutButton')
-    expect(navigateSpy).toHaveBeenCalledWith(['/login'])
+    const location = TestBed.inject(Location)
+    expect(location.path()).toBe('/login')
   })
 
   it('handle backend error during logout', async () => {
@@ -143,8 +146,9 @@ describe('AppComponent', () => {
 
   it('display go home link on non-home page only', async () => {
     const {
-      appHarness, router
+      appHarness
     } = await initComponent()
+    const router = TestBed.inject(Router)
 
     await router.navigate(['non-home'])
     expect(await appHarness.elementVisible('navToHomeLink')).toBe(true)
@@ -158,11 +162,11 @@ describe('AppComponent', () => {
 
   it('navigate to home page on link click', async () => {
     const {
-      appHarness, router
+      appHarness
     } = await initComponent()
-    const navigateByUrlSpy = spyOn<Router, 'navigateByUrl'>(router, 'navigateByUrl')
 
     await appHarness.clickLink('navToHomeLink')
-    expect(navigateByUrlSpy).toHaveBeenCalledWith(router.createUrlTree(['/home']), jasmine.anything())
+    const location = TestBed.inject(Location)
+    expect(location.path()).toBe('/home')
   })
 })

--- a/src/app/tests/app.routes.spec.ts
+++ b/src/app/tests/app.routes.spec.ts
@@ -2,9 +2,6 @@ import {
   TestBed
 } from '@angular/core/testing'
 import {
-  Router
-} from '@angular/router'
-import {
   RouterTestingHarness,
   RouterTestingModule
 } from '@angular/router/testing'
@@ -20,11 +17,14 @@ import {
 import {
   AuthService
 } from '../services/auth/auth.service'
+import {
+  Location
+} from '@angular/common'
 
 describe('App navigation', () => {
   let isAuthMock: BehaviorSubject<boolean>
   let routerHarness: RouterTestingHarness
-  let router: Router
+  let location: Location
 
   beforeEach(async () => {
     isAuthMock = new BehaviorSubject(true)
@@ -40,28 +40,28 @@ describe('App navigation', () => {
     }).compileComponents()
 
     routerHarness = await RouterTestingHarness.create()
-    router = TestBed.inject(Router)
+    location = TestBed.inject(Location)
   })
 
   it('authenticated user - redirected to home page by default', async () => {
     isAuthMock.next(true)
 
     await routerHarness.navigateByUrl('/')
-    expect(router.url).toBe('/home')
+    expect(location.path()).toBe('/home')
   })
 
   it('authenticated user - redirected to home page when trying to open login page', async () => {
     isAuthMock.next(true)
 
     await routerHarness.navigateByUrl('/login')
-    expect(router.url).toBe('/home')
+    expect(location.path()).toBe('/home')
   })
 
   it('authenticated user - could access non-login page', async () => {
     isAuthMock.next(true)
 
     await routerHarness.navigateByUrl('/home')
-    expect(router.url).toBe('/home')
+    expect(location.path()).toBe('/home')
   })
 
   it('authenticated user - unknown path handling should be configured', async () => {
@@ -74,27 +74,27 @@ describe('App navigation', () => {
     isAuthMock.next(false)
 
     await routerHarness.navigateByUrl('/')
-    expect(router.url).toBe('/login')
+    expect(location.path()).toBe('/login')
   })
 
   it('non-authenticated user - redirected to login page when trying to open non-login page', async () => {
     isAuthMock.next(false)
 
     await routerHarness.navigateByUrl('/home')
-    expect(router.url).toBe('/login')
+    expect(location.path()).toBe('/login')
   })
 
   it('non-authenticated user - could access login page', async () => {
     isAuthMock.next(false)
 
     await routerHarness.navigateByUrl('/login')
-    expect(router.url).toBe('/login')
+    expect(location.path()).toBe('/login')
   })
 
   it('non-authenticated user - unknown path redirects to login page', async () => {
     isAuthMock.next(false)
 
     await routerHarness.navigateByUrl('/unknownRoute')
-    expect(router.url).toBe('/login')
+    expect(location.path()).toBe('/login')
   })
 })


### PR DESCRIPTION
Spying on navigation methods poses several issues:
1) spying does not guarantee the invokation of the method produces expected result:
```javascirpt
this.router.navigate(['/test', {queryParams}])
```
with assertion:
```javascript
expect(navigateSpy).toHaveBeenCalledWith(['/test', {queryParams}])
```
will pass although it won't produce expected URL since queryParams should go AFTER the array, not INSIDE of it

2) there are numerous ways to navigate: _**routerLink, navigate, navigateByUrl, navigationBackService**_, etc.
Spying on all of them is too much and leaks the implementation details

Instead we should focus on **_Location.path()_** method that provides a single source of truth for navigation: browser URL 

It works with all the combinations.
We only need to make sure used paths are passed to withRoutes array.