### PR TITLE
move message box methods to utilities

### DIFF
--- a/src/app/tests/foundation/tests/test.component.spec.ts
+++ b/src/app/tests/foundation/tests/test.component.spec.ts
@@ -11,6 +11,9 @@ import {
 import {
   TestComponentHarness
 } from './test.component.harness'
+import {
+  Utilities
+} from '../utilities'
 
 describe('Base harness', () => {
   let baseHarness: TestComponentHarness
@@ -184,26 +187,26 @@ describe('Base harness', () => {
     expect(formValuesOnBlur.pop()).toBeUndefined()
   })
 
-  it('actOnMessageBox', async () => {
+  it('Utilities - actOnMessageBox', async () => {
     expect(await baseHarness.elementText('message-box-confirmation-status')).toBe('Rejected')
 
-    await baseHarness.actOnMessageBox(async () => {
+    await Utilities.actOnMessageBox(async () => {
       await baseHarness.clickButton('button-triggers-message-box-confirmation')
     }, 'confirm')
     expect(await baseHarness.elementText('message-box-confirmation-status')).toBe('Confirmed')
 
-    await baseHarness.actOnMessageBox(async () => {
+    await Utilities.actOnMessageBox(async () => {
       await baseHarness.clickButton('button-triggers-message-box-confirmation')
     }, 'cancel')
     expect(await baseHarness.elementText('message-box-confirmation-status')).toBe('Rejected')
   })
 
-  it('errorMessageBoxPresent', async () => {
-    expect(await baseHarness.errorMessageBoxPresent(async () => {
+  it('Utilities - errorMessageBoxPresent', async () => {
+    expect(await Utilities.errorMessageBoxPresent(async () => {
       await baseHarness.clickButton('button-triggers-message-box-error')
     })).toBe(true)
 
-    expect(await baseHarness.errorMessageBoxPresent(async () => {
+    expect(await Utilities.errorMessageBoxPresent(async () => {
       await baseHarness.clickButton('button-triggers-no-message-box-error')
     })).toBe(false)
   })

--- a/src/app/tests/foundation/utilities.ts
+++ b/src/app/tests/foundation/utilities.ts
@@ -1,0 +1,31 @@
+export class Utilities {
+  public static async actOnMessageBox(actions: () => Promise<void>, action: 'confirm' | 'cancel'): Promise<void> {
+    const windowConfirmOriginal = window.confirm
+    /* eslint-disable-next-line jasmine/no-unsafe-spy */
+    const confirmSpy = spyOn<typeof window, 'confirm'>(window, 'confirm')
+    if (action === 'confirm') {
+      confirmSpy.and.returnValue(true)
+    }
+    if (action === 'cancel') {
+      confirmSpy.and.returnValue(false)
+    }
+
+    await actions()
+
+    // restore window.confirm manually since Jasmine doesn't provide unspy method
+    window.confirm = windowConfirmOriginal
+  }
+
+  public static async errorMessageBoxPresent(actions: () => Promise<void>): Promise<boolean> {
+    const windowAlertOriginal = window.alert
+    /* eslint-disable-next-line jasmine/no-unsafe-spy */
+    const errorSpy = spyOn<typeof window, 'alert'>(window, 'alert')
+
+    await actions()
+
+    // restore window.alert manually since Jasmine doesn't provide unspy method
+    window.alert = windowAlertOriginal
+
+    return errorSpy.calls.any()
+  }
+}


### PR DESCRIPTION
sometimes we need to work with message box when harness is not available;
message box is not really related to component harness;
to address that, we move such methods to utilities class;