### PR TITLE
do not spy on backend error handler in tests

### DIFF
--- a/src/app/components/contract/tests/contract.component.spec.ts
+++ b/src/app/components/contract/tests/contract.component.spec.ts
@@ -26,18 +26,17 @@ import {
   throwError
 } from 'rxjs'
 import {
-  BackendErrorHandlerService
-} from '../../../services/backend-error-handler/backend-error-handler.service'
-import {
   Location
 } from '@angular/common'
 import {
   Contract
 } from '../../../interfaces/contract'
+import {
+  Utilities
+} from '../../../tests/foundation/utilities'
 
 describe('ContractComponent', () => {
   let contractServiceMock: jasmine.SpyObj<ContractService>
-  let backendErrorHandlerServiceMock: jasmine.SpyObj<BackendErrorHandlerService>
   const existingContract: Contract = {
     id: 'some_contract_id',
     number: 'APX1000',
@@ -72,16 +71,10 @@ describe('ContractComponent', () => {
           }
         ])
       ],
-      providers: [
-        {
-          provide: ContractService,
-          useValue: contractServiceMock
-        },
-        {
-          provide: BackendErrorHandlerService,
-          useValue: backendErrorHandlerServiceMock
-        }
-      ]
+      providers: [{
+        provide: ContractService,
+        useValue: contractServiceMock
+      }]
     }).compileComponents()
 
     const routerHarness = await RouterTestingHarness.create('/initial')
@@ -108,10 +101,9 @@ describe('ContractComponent', () => {
     contracts.forEach((contract) => {
       contractServiceMock.getContract.withArgs(contract.id).and.returnValue(of(contract))
     })
-    backendErrorHandlerServiceMock = jasmine.createSpyObj<BackendErrorHandlerService>('backendErrorHandler', ['handleError'])
   })
 
-  it('enable/disable create button based on form validity', async () => {
+  it('common - enable/disable create button based on form validity', async () => {
     const {
       contractHarness
     } = await initComponent()
@@ -146,7 +138,7 @@ describe('ContractComponent', () => {
     expect(await contractHarness.buttonEnabled('saveContractButton')).toBe(false)
   })
 
-  it('display/hide error message based on number validity', async () => {
+  it('common - display/hide error message based on number validity', async () => {
     const {
       contractHarness
     } = await initComponent()
@@ -169,7 +161,7 @@ describe('ContractComponent', () => {
     expect(await contractHarness.elementVisible('numberErrorEmpty')).toBe(true)
   })
 
-  it('display/hide error message based on conditions validity', async () => {
+  it('common - display/hide error message based on conditions validity', async () => {
     const {
       contractHarness
     } = await initComponent()
@@ -192,7 +184,7 @@ describe('ContractComponent', () => {
     expect(await contractHarness.elementVisible('conditionsErrorEmpty')).toBe(true)
   })
 
-  it('navigate back on successful creation', async () => {
+  it('add - navigate back on success', async () => {
     contractServiceMock.createContract.and.returnValue(of('new_contract_id'))
     const {
       contractHarness
@@ -210,7 +202,7 @@ describe('ContractComponent', () => {
     expect(location.path()).toBe('/initial')
   })
 
-  it('handle backend error during creation', async () => {
+  it('add - handle backend error', async () => {
     contractServiceMock.createContract.and.callFake(() => {
       return throwError(() => new Error('something went wrong'))
     })
@@ -222,15 +214,16 @@ describe('ContractComponent', () => {
       conditions: '3 year labour contract'
     }
 
-    await contractHarness.enterValue('numberInput', contractToCreate.number)
-    await contractHarness.enterValue('conditionsInput', contractToCreate.conditions)
-    await contractHarness.clickButton('saveContractButton')
-    expect(backendErrorHandlerServiceMock.handleError).toHaveBeenCalledWith()
+    expect(await Utilities.errorMessageBoxPresent(async () => {
+      await contractHarness.enterValue('numberInput', contractToCreate.number)
+      await contractHarness.enterValue('conditionsInput', contractToCreate.conditions)
+      await contractHarness.clickButton('saveContractButton')
+    })).toBe(true)
     const location = TestBed.inject(Location)
     expect(location.path()).toBe('/contract')
   })
 
-  it('navigate back on successful edition', async () => {
+  it('edit - navigate back on success', async () => {
     contractServiceMock.updateContract.and.returnValue(of(void 0))
     const {
       contractHarness
@@ -248,7 +241,7 @@ describe('ContractComponent', () => {
     expect(location.path()).toBe('/initial')
   })
 
-  it('handle backend error during edition', async () => {
+  it('edit - handle backend error', async () => {
     contractServiceMock.updateContract.and.callFake(() => {
       return throwError(() => new Error('something went wrong'))
     })
@@ -260,15 +253,16 @@ describe('ContractComponent', () => {
       conditions: `${existingContract.conditions} (edited)`
     }
 
-    await contractHarness.enterValue('numberInput', contractToUpdate.number)
-    await contractHarness.enterValue('conditionsInput', contractToUpdate.conditions)
-    await contractHarness.clickButton('saveContractButton')
-    expect(backendErrorHandlerServiceMock.handleError).toHaveBeenCalledWith()
+    expect(await Utilities.errorMessageBoxPresent(async () => {
+      await contractHarness.enterValue('numberInput', contractToUpdate.number)
+      await contractHarness.enterValue('conditionsInput', contractToUpdate.conditions)
+      await contractHarness.clickButton('saveContractButton')
+    })).toBe(true)
     const location = TestBed.inject(Location)
     expect(location.path()).toBe(`/contract?contractId=${existingContract.id}`)
   })
 
-  it('navigate back on cancel', async () => {
+  it('common - navigate back on cancel', async () => {
     const {
       contractHarness
     } = await initComponent()
@@ -284,7 +278,7 @@ describe('ContractComponent', () => {
     expect(location.path()).toBe('/initial')
   })
 
-  it('edit mode - populate form with existing contract data', async () => {
+  it('edit - populate form with existing contract data', async () => {
     const {
       contractHarness, routerHarness
     } = await initComponent()
@@ -295,7 +289,7 @@ describe('ContractComponent', () => {
     expect(await contractHarness.buttonEnabled('saveContractButton')).toBe(true)
   })
 
-  it('edit mode - form reacts to query param change', async () => {
+  it('edit - form reacts to query param change', async () => {
     const {
       contractHarness, routerHarness
     } = await initComponent()
@@ -312,7 +306,7 @@ describe('ContractComponent', () => {
     expect(await contractHarness.buttonEnabled('saveContractButton')).toBe(true)
   })
 
-  it('edit mode - form is cleared when switching to add mode', async () => {
+  it('edit - form is cleared when switching to add mode', async () => {
     const {
       contractHarness, routerHarness
     } = await initComponent()
@@ -329,7 +323,7 @@ describe('ContractComponent', () => {
     expect(await contractHarness.buttonEnabled('saveContractButton')).toBe(false)
   })
 
-  it('edit mode - form is populated when switching from add mode', async () => {
+  it('edit - form is populated when switching from add mode', async () => {
     const {
       contractHarness, routerHarness
     } = await initComponent()
@@ -347,7 +341,7 @@ describe('ContractComponent', () => {
     expect(await contractHarness.buttonEnabled('saveContractButton')).toBe(true)
   })
 
-  it('edit mode - form remains empty in case of data fetch error', async () => {
+  it('edit - form remains empty in case of data fetch error', async () => {
     contractServiceMock.getContract.withArgs(existingContract.id).and.callFake(() => {
       return throwError(() => new Error('something went wrong'))
     })
@@ -355,15 +349,15 @@ describe('ContractComponent', () => {
       contractHarness, routerHarness
     } = await initComponent()
 
-    await routerHarness.navigateByUrl(`/contract?contractId=${existingContract.id}`)
-
+    expect(await Utilities.errorMessageBoxPresent(async () => {
+      await routerHarness.navigateByUrl(`/contract?contractId=${existingContract.id}`)
+    })).toBe(true)
     expect(await contractHarness.inputValue('numberInput')).toBe('')
     expect(await contractHarness.inputValue('conditionsInput')).toBe('')
     expect(await contractHarness.buttonEnabled('saveContractButton')).toBe(false)
-    expect(backendErrorHandlerServiceMock.handleError).toHaveBeenCalledWith()
   })
 
-  it('edit mode - form populated after data fetch error on param change', async () => {
+  it('edit - form populated after data fetch error on param change', async () => {
     contractServiceMock.getContract.withArgs(existingContract.id).and.callFake(() => {
       return throwError(() => new Error('something went wrong'))
     })
@@ -379,7 +373,7 @@ describe('ContractComponent', () => {
     expect(await contractHarness.buttonEnabled('saveContractButton')).toBe(true)
   })
 
-  it('edit mode - form data is not changed on data fetch error after param change', async () => {
+  it('edit - form data is not changed on data fetch error after param change', async () => {
     contractServiceMock.getContract.withArgs(anotherExistingContract.id).and.callFake(() => {
       return throwError(() => new Error('something went wrong'))
     })

--- a/src/app/components/login/test/login.component.spec.ts
+++ b/src/app/components/login/test/login.component.spec.ts
@@ -29,18 +29,17 @@ import {
   RouterTestingModule
 } from '@angular/router/testing'
 import {
-  BackendErrorHandlerService
-} from '../../../services/backend-error-handler/backend-error-handler.service'
-import {
   TestComponent
 } from '../../../tests/utils'
 import {
   Location
 } from '@angular/common'
+import {
+  Utilities
+} from '../../../tests/foundation/utilities'
 
 describe('LoginComponent', () => {
   let authServiceMock: jasmine.SpyObj<AuthService>
-  let backendErrorHandlerServiceMock: jasmine.SpyObj<BackendErrorHandlerService>
   const VALID_CREDS = {
     login: 'my_login',
     password: 'my_password'
@@ -58,16 +57,10 @@ describe('LoginComponent', () => {
           component: TestComponent
         }])
       ],
-      providers: [
-        {
-          provide: AuthService,
-          useValue: authServiceMock
-        },
-        {
-          provide: BackendErrorHandlerService,
-          useValue: backendErrorHandlerServiceMock
-        }
-      ]
+      providers: [{
+        provide: AuthService,
+        useValue: authServiceMock
+      }]
     }).compileComponents()
 
     const fixture = TestBed.createComponent(LoginComponent)
@@ -89,8 +82,6 @@ describe('LoginComponent', () => {
         }))
       }
     })
-
-    backendErrorHandlerServiceMock = jasmine.createSpyObj<BackendErrorHandlerService>('backendErrorHandler', ['handleError'])
   })
 
   it('enable/disable login button based on form validity', async () => {
@@ -204,9 +195,10 @@ describe('LoginComponent', () => {
       loginHarness
     } = await initComponent()
 
-    await loginHarness.enterValue('loginInput', VALID_CREDS.login)
-    await loginHarness.enterValue('passwordInput', VALID_CREDS.password)
-    await loginHarness.clickButton('loginButton')
-    expect(backendErrorHandlerServiceMock.handleError).toHaveBeenCalledWith()
+    expect(await Utilities.errorMessageBoxPresent(async () => {
+      await loginHarness.enterValue('loginInput', VALID_CREDS.login)
+      await loginHarness.enterValue('passwordInput', VALID_CREDS.password)
+      await loginHarness.clickButton('loginButton')
+    })).toBe(true)
   })
 })

--- a/src/app/tests/app.component.spec.ts
+++ b/src/app/tests/app.component.spec.ts
@@ -29,19 +29,18 @@ import {
   TestbedHarnessEnvironment
 } from '@angular/cdk/testing/testbed'
 import {
-  BackendErrorHandlerService
-} from '../services/backend-error-handler/backend-error-handler.service'
-import {
   TestComponent
 } from './utils'
 import {
   Location
 } from '@angular/common'
+import {
+  Utilities
+} from './foundation/utilities'
 
 describe('AppComponent', () => {
   let isAuthMock: BehaviorSubject<boolean>
   let authServiceMock: jasmine.SpyObj<AuthService>
-  let backendErrorHandlerServiceMock: jasmine.SpyObj<BackendErrorHandlerService>
 
   async function initComponent(): Promise<{
     appHarness: AppHarness
@@ -69,16 +68,10 @@ describe('AppComponent', () => {
           }
         ])
       ],
-      providers: [
-        {
-          provide: AuthService,
-          useValue: authServiceMock
-        },
-        {
-          provide: BackendErrorHandlerService,
-          useValue: backendErrorHandlerServiceMock
-        }
-      ]
+      providers: [{
+        provide: AuthService,
+        useValue: authServiceMock
+      }]
     }).compileComponents()
 
     const fixture = TestBed.createComponent(AppComponent)
@@ -96,8 +89,6 @@ describe('AppComponent', () => {
     ])
     authServiceMock.isAuth.and.returnValue(isAuthMock)
     authServiceMock.logout.and.returnValue(of(undefined))
-
-    backendErrorHandlerServiceMock = jasmine.createSpyObj<BackendErrorHandlerService>('backendErrorHandler', ['handleError'])
   })
 
   it('display translated welcome message', async () => {
@@ -126,8 +117,9 @@ describe('AppComponent', () => {
       appHarness
     } = await initComponent()
 
-    await appHarness.clickButton('logoutButton')
-    expect(backendErrorHandlerServiceMock.handleError).toHaveBeenCalledWith()
+    expect (await Utilities.errorMessageBoxPresent(async () => {
+      await appHarness.clickButton('logoutButton')
+    })).toBe(true)
   })
 
   it('display header only to authenticated user', async () => {

--- a/src/app/tests/foundation/base.component.harness.ts
+++ b/src/app/tests/foundation/base.component.harness.ts
@@ -58,36 +58,6 @@ export class BaseHarness extends ComponentHarness {
     }
   }
 
-  public async actOnMessageBox(actions: () => Promise<void>, action: 'confirm' | 'cancel'): Promise<void> {
-    const windowConfirmOriginal = window.confirm
-    /* eslint-disable-next-line jasmine/no-unsafe-spy */
-    const confirmSpy = spyOn<typeof window, 'confirm'>(window, 'confirm')
-    if (action === 'confirm') {
-      confirmSpy.and.returnValue(true)
-    }
-    if (action === 'cancel') {
-      confirmSpy.and.returnValue(false)
-    }
-
-    await actions()
-
-    // restore window.confirm manually since Jasmine doesn't provide unspy method
-    window.confirm = windowConfirmOriginal
-  }
-
-  public async errorMessageBoxPresent(actions: () => Promise<void>): Promise<boolean> {
-    const windowAlertOriginal = window.alert
-    /* eslint-disable-next-line jasmine/no-unsafe-spy */
-    const errorSpy = spyOn<typeof window, 'alert'>(window, 'alert')
-
-    await actions()
-
-    // restore window.alert manually since Jasmine doesn't provide unspy method
-    window.alert = windowAlertOriginal
-
-    return errorSpy.calls.any()
-  }
-
   /********************************
    * ASSERTIONS
    *******************************/


### PR DESCRIPTION
what we are really intersted in is what we can see, not the implementation details;
use message box utils to check error message box presence since this is what we see in case of backend errors; 
remove backend error handling spies from tests;