### PR TITLE
fix paginator get range label

### DIFF
--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -13,6 +13,6 @@
         "NEXT_PAGE_LABEL": "To next",
         "PREVIOUS_PAGE_LABEL": "To previous",
         "ITEMS_PER_PAGE_LABEL": "Items per page:",
-        "FROM_ITEM_TO_ITEM_OUT_OF_ITEMS": "{{fromItem}} - {{toItem}} out of {{items}}"
+        "FROM_ITEM_TO_ITEM_OUT_OF_ITEMS": "{{fromItem}} - {{toItem}} out of {{totalItems}}"
     }
 }

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -13,6 +13,6 @@
         "NEXT_PAGE_LABEL": "К следующей",
         "PREVIOUS_PAGE_LABEL": "К предыдущей",
         "ITEMS_PER_PAGE_LABEL": "Позиций на странице:",
-        "FROM_ITEM_TO_ITEM_OUT_OF_ITEMS": "{{fromItem}} - {{toItem}} из {{items}}"
+        "FROM_ITEM_TO_ITEM_OUT_OF_ITEMS": "{{fromItem}} - {{toItem}} из {{totalItems}}"
     }
 }

--- a/src/transloco/custom-mat-paginator-intl.service.ts
+++ b/src/transloco/custom-mat-paginator-intl.service.ts
@@ -33,11 +33,13 @@ export class CustomMatPaginatorIntlService extends MatPaginatorIntl implements O
     })
   }
 
-  public override getRangeLabel = (page: number, pageSize: number, length: number): string => {
+  public override getRangeLabel = (page: number, pageSize: number, totalItems: number): string => {
+    const fromItem = page * pageSize
+    const toItem = fromItem + pageSize > totalItems ? totalItems : fromItem + pageSize
     return this.ts.translate('PAGINATOR.FROM_ITEM_TO_ITEM_OUT_OF_ITEMS', {
-      fromItem: page * pageSize,
-      toItem: (page + 1) * pageSize,
-      items: length
+      fromItem: fromItem,
+      toItem: toItem,
+      totalItems: totalItems
     })
   }
 


### PR DESCRIPTION
if there are fewer elements on the page than possible, use number of items as toItem e.g.:
page: 2
pageSize: 10
total items: 27

current implementation: 20-30 out of 27
fixed implementation: 20-27 out of 27