### PR TITLE
refactor waiting harness

### DIFF
--- a/src/app/tests/foundation/tests/test.component.spec.ts
+++ b/src/app/tests/foundation/tests/test.component.spec.ts
@@ -27,7 +27,7 @@ import {
   of
 } from 'rxjs'
 
-describe('Base harness', () => {
+describe('Base harnesses', () => {
   let baseHarness: TestComponentHarness
   let waitingBaseHarness: WaitingTestComponentHarness
   let testComponent: TestComponent
@@ -335,7 +335,7 @@ describe('Base harness', () => {
     stream.pipe(busyStateService.processLoading('div-busy')).subscribe()
     await expectAsync(baseHarness.elementBusy(elementId)).toBeResolvedTo(true)
 
-    await waitingBaseHarness.waitForElementFree(elementId)
+    await waitingBaseHarness.expectElementFree(elementId)
     await expectAsync(baseHarness.elementBusy(elementId)).toBeResolvedTo(false)
   })
 
@@ -352,7 +352,7 @@ describe('Base harness', () => {
     await expectAsync(baseHarness.elementBusy(elementId)).toBeResolvedTo(true)
 
     // wait less than the delay in the stream
-    await expectAsync(waitingBaseHarness.withTimeout(EMITTER_DELAY).waitForElementFree(elementId)).toBeRejectedWithError(`Waiting for element ${elementId} becoming free failed: timeout exceeded, but element is still busy.`)
+    await expectAsync(waitingBaseHarness.withTimeout(EMITTER_DELAY).expectElementFree(elementId)).toBeRejectedWithError(`Waiting for element ${elementId} becoming free failed: timeout exceeded, but element is still busy.`)
   })
 
   it('waiting harness - element present', async () => {
@@ -368,7 +368,7 @@ describe('Base harness', () => {
     })
     await expectAsync(baseHarness.elementPresent(elementId, 'div')).toBeResolvedTo(false)
 
-    await waitingBaseHarness.waitForElementPresent(elementId)
+    await waitingBaseHarness.expectElementPresent(elementId)
     await expectAsync(baseHarness.elementPresent(elementId, 'div')).toBeResolvedTo(true)
   })
 
@@ -380,13 +380,14 @@ describe('Base harness', () => {
 
     await expectAsync(baseHarness.elementPresent(elementId, 'div')).toBeResolvedTo(false)
 
-    stream.subscribe(() => {
+    const subscription = stream.subscribe(() => {
       testComponent.isPresent.next(true)
     })
     await expectAsync(baseHarness.elementPresent(elementId, 'div')).toBeResolvedTo(false)
 
     // wait less than the delay in the stream
-    await expectAsync(waitingBaseHarness.withTimeout(EMITTER_DELAY).waitForElementPresent(elementId)).toBeRejectedWithError(`Waiting for element ${elementId} being present failed: timeout exceeded, but element is still not present.`)
+    await expectAsync(waitingBaseHarness.withTimeout(EMITTER_DELAY).expectElementPresent(elementId)).toBeRejectedWithError(`Waiting for element ${elementId} being present failed: timeout exceeded, but element is still not present.`)
+    subscription.unsubscribe()
   })
 
   it('waiting harness - element not present', async () => {
@@ -402,7 +403,7 @@ describe('Base harness', () => {
     })
     await expectAsync(baseHarness.elementPresent(elementId, 'div')).toBeResolvedTo(true)
 
-    await waitingBaseHarness.waitForElementPresent(elementId, false)
+    await waitingBaseHarness.expectElementPresent(elementId, false)
     await expectAsync(baseHarness.elementPresent(elementId, 'div')).toBeResolvedTo(false)
   })
 
@@ -414,12 +415,13 @@ describe('Base harness', () => {
 
     await expectAsync(baseHarness.elementPresent(elementId, 'div')).toBeResolvedTo(true)
 
-    stream.subscribe(() => {
+    const subscription = stream.subscribe(() => {
       testComponent.isPresent.next(true)
     })
     await expectAsync(baseHarness.elementPresent(elementId, 'div')).toBeResolvedTo(true)
 
     // wait less than the delay in the stream
-    await expectAsync(waitingBaseHarness.withTimeout(EMITTER_DELAY).waitForElementPresent(elementId, false)).toBeRejectedWithError(`Waiting for element ${elementId} not being present failed: timeout exceeded, but element is still present.`)
+    await expectAsync(waitingBaseHarness.withTimeout(EMITTER_DELAY).expectElementPresent(elementId, false)).toBeRejectedWithError(`Waiting for element ${elementId} not being present failed: timeout exceeded, but element is still present.`)
+    subscription.unsubscribe()
   })
 })

--- a/src/app/tests/foundation/waiting.component.harness.ts
+++ b/src/app/tests/foundation/waiting.component.harness.ts
@@ -1,4 +1,8 @@
 import {
+  ComponentHarness,
+  TestElement
+} from '@angular/cdk/testing'
+import {
   BaseHarness
 } from './base.component.harness'
 
@@ -19,15 +23,24 @@ export class WaitingHarness extends BaseHarness {
   protected waitForTimeoutInterval = 15000
   protected waitForPollingInterval = 400
 
-  protected async waitFor(condition: () => Promise<boolean>, errorMessage: string): Promise<void> {
-    let conditionFulfilled = await condition()
+  protected async waitFor(
+    lookup: () => Promise<TestElement | ComponentHarness | boolean>,
+    errorMessage: string,
+    action?: (result: TestElement | ComponentHarness | boolean) => Promise<void>
+  ): Promise<void> {
+    let result = await lookup()
     const endTime = Date.now() + this.waitForTimeoutInterval
-    while (!conditionFulfilled && Date.now() < endTime) {
+    while (!result && Date.now() < endTime) {
       await wait(this.waitForPollingInterval)
-      conditionFulfilled = await condition()
+      result = await lookup()
     }
-    if (!conditionFulfilled) {
+    if (!result) {
       throw new Error(errorMessage)
+    }
+    else {
+      if (action) {
+        action(result)
+      }
     }
   }
 
@@ -46,20 +59,15 @@ export class WaitingHarness extends BaseHarness {
   }
 
   // for elements blocked with appBusy directive
-  public async waitForElementFree(id: string): Promise<void> {
-    const condition = async (): Promise<boolean> => {
+  public async expectElementFree(id: string): Promise<void> {
+    await this.waitFor(async () => {
       const cssSelector = this.getCssSelector(id, ['div'], this.ancestorSelector, ':not([data-busy="true"])')
       return !!(await this.locatorForOptional(cssSelector)())
-    }
-    await this.waitFor(condition, `Waiting for element ${id} becoming free failed: timeout exceeded, but element is still busy.`)
+    }, `Waiting for element ${id} becoming free failed: timeout exceeded, but element is still busy.`)
   }
 
   // for elements hidden via @if + async
-  public async waitForElementPresent(id: string, present: boolean = true): Promise<void> {
-    const condition = async (): Promise<boolean> => {
-      const cssSelector = this.getCssSelector(id, ['div'], this.ancestorSelector)
-      return !!(await this.locatorForOptional(cssSelector)()) === present
-    }
+  public async expectElementPresent(id: string, present: boolean = true): Promise<void> {
     let errorMessage: string
     if (present) {
       errorMessage = `Waiting for element ${id} being present failed: timeout exceeded, but element is still not present.`
@@ -67,6 +75,9 @@ export class WaitingHarness extends BaseHarness {
     else {
       errorMessage = `Waiting for element ${id} not being present failed: timeout exceeded, but element is still present.`
     }
-    await this.waitFor(condition, errorMessage)
+    await this.waitFor(async () => {
+      const cssSelector = this.getCssSelector(id, ['div'], this.ancestorSelector)
+      return !!(await this.locatorForOptional(cssSelector)()) === present
+    }, errorMessage)
   }
 }


### PR DESCRIPTION
1. replace 'waitFor' prefix with 'expect';
2. Prepare waitFor for reuse for actions;
3. unsubscribe from timeout to stabilize and isolate tests;