### PR TITLE
change assertion strategy

### DIFF
--- a/src/app/components/contract/tests/contract.component.spec.ts
+++ b/src/app/components/contract/tests/contract.component.spec.ts
@@ -74,32 +74,32 @@ describe('ContractComponent', () => {
 
     // initial state
     // invalid form: number missing, conditions missing
-    expect(await harnesses.router.component.buttonEnabled('saveContractButton')).toBe(false)
+    await harnesses.router.component.expectButtonEnabled('saveContractButton', false)
 
     // invalid form: number present, conditions missing
     await harnesses.router.component.enterValue('numberInput', 'APX3000')
-    expect(await harnesses.router.component.buttonEnabled('saveContractButton')).toBe(false)
+    await harnesses.router.component.expectButtonEnabled('saveContractButton', false)
 
     // valid form: number present, conditions present
     await harnesses.router.component.enterValue('conditionsInput', '3 year labour contract')
-    expect(await harnesses.router.component.buttonEnabled('saveContractButton')).toBe(true)
+    await harnesses.router.component.expectButtonEnabled('saveContractButton', true)
 
     // valid form: number present, conditions missing
     await harnesses.router.component.enterValue('conditionsInput', '')
-    expect(await harnesses.router.component.buttonEnabled('saveContractButton')).toBe(false)
+    await harnesses.router.component.expectButtonEnabled('saveContractButton', false)
 
     // valid form: number present, conditions missing (whitespaces are ignored for conditions)
     await harnesses.router.component.enterValue('conditionsInput', ' ')
-    expect(await harnesses.router.component.buttonEnabled('saveContractButton')).toBe(false)
+    await harnesses.router.component.expectButtonEnabled('saveContractButton', false)
 
     // invalid form: number missing, conditions present
     await harnesses.router.component.enterValue('conditionsInput', '3 year labour contract')
     await harnesses.router.component.enterValue('numberInput', '')
-    expect(await harnesses.router.component.buttonEnabled('saveContractButton')).toBe(false)
+    await harnesses.router.component.expectButtonEnabled('saveContractButton', false)
 
     // invalid form: number missing, conditions present (whitespaces are ignored for number)
     await harnesses.router.component.enterValue('numberInput', ' ')
-    expect(await harnesses.router.component.buttonEnabled('saveContractButton')).toBe(false)
+    await harnesses.router.component.expectButtonEnabled('saveContractButton', false)
   })
 
   it('common - display/hide error message based on number validity', async () => {
@@ -108,21 +108,21 @@ describe('ContractComponent', () => {
     } = await initComponent()
 
     // initial state: no validation done
-    expect(await harnesses.router.component.elementVisible('numberErrorEmpty')).toBe(false)
+    await harnesses.router.component.expectElementVisible('numberErrorEmpty', false)
 
     // validation is not triggered until blur
     await harnesses.router.component.enterValue('numberInput', '', false)
-    expect(await harnesses.router.component.elementVisible('numberErrorEmpty')).toBe(false)
+    await harnesses.router.component.expectElementVisible('numberErrorEmpty', false)
 
     await harnesses.router.component.enterValue('numberInput', '')
-    expect(await harnesses.router.component.elementVisible('numberErrorEmpty')).toBe(true)
+    await harnesses.router.component.expectElementVisible('numberErrorEmpty', true)
 
     await harnesses.router.component.enterValue('numberInput', 'APX3000')
-    expect(await harnesses.router.component.elementVisible('numberErrorEmpty')).toBe(false)
+    await harnesses.router.component.expectElementVisible('numberErrorEmpty', false)
 
     // whitespaces are ignored
     await harnesses.router.component.enterValue('numberInput', ' ')
-    expect(await harnesses.router.component.elementVisible('numberErrorEmpty')).toBe(true)
+    await harnesses.router.component.expectElementVisible('numberErrorEmpty', true)
   })
 
   it('common - display/hide error message based on conditions validity', async () => {
@@ -131,21 +131,21 @@ describe('ContractComponent', () => {
     } = await initComponent()
 
     // initial state: no validation done
-    expect(await harnesses.router.component.elementVisible('conditionsErrorEmpty')).toBe(false)
+    await harnesses.router.component.expectElementVisible('conditionsErrorEmpty', false)
 
     // validation is not triggered until blur
     await harnesses.router.component.enterValue('conditionsInput', '', false)
-    expect(await harnesses.router.component.elementVisible('conditionsErrorEmpty')).toBe(false)
+    await harnesses.router.component.expectElementVisible('conditionsErrorEmpty', false)
 
     await harnesses.router.component.enterValue('conditionsInput', '')
-    expect(await harnesses.router.component.elementVisible('conditionsErrorEmpty')).toBe(true)
+    await harnesses.router.component.expectElementVisible('conditionsErrorEmpty', true)
 
     await harnesses.router.component.enterValue('conditionsInput', '3 year labour contract')
-    expect(await harnesses.router.component.elementVisible('conditionsErrorEmpty')).toBe(false)
+    await harnesses.router.component.expectElementVisible('conditionsErrorEmpty', false)
 
     // whitespaces are ignored
     await harnesses.router.component.enterValue('conditionsInput', ' ')
-    expect(await harnesses.router.component.elementVisible('conditionsErrorEmpty')).toBe(true)
+    await harnesses.router.component.expectElementVisible('conditionsErrorEmpty', true)
   })
 
   it('add - navigate back on success', async () => {
@@ -237,9 +237,9 @@ describe('ContractComponent', () => {
     } = await initComponent()
     await harnesses.router.navigateByUrl(`/contract?contractId=${existingContract.id}`)
 
-    expect(await harnesses.router.component.inputValue('numberInput')).toBe(existingContract.number)
-    expect(await harnesses.router.component.inputValue('conditionsInput')).toBe(existingContract.conditions)
-    expect(await harnesses.router.component.buttonEnabled('saveContractButton')).toBe(true)
+    await harnesses.router.component.expectInputValue('numberInput', existingContract.number)
+    await harnesses.router.component.expectInputValue('conditionsInput', existingContract.conditions)
+    await harnesses.router.component.expectButtonEnabled('saveContractButton', true)
   })
 
   it('edit - form reacts to query param change', async () => {
@@ -248,15 +248,15 @@ describe('ContractComponent', () => {
     } = await initComponent()
     await harnesses.router.navigateByUrl(`/contract?contractId=${existingContract.id}`)
 
-    expect(await harnesses.router.component.inputValue('numberInput')).toBe(existingContract.number)
-    expect(await harnesses.router.component.inputValue('conditionsInput')).toBe(existingContract.conditions)
-    expect(await harnesses.router.component.buttonEnabled('saveContractButton')).toBe(true)
+    await harnesses.router.component.expectInputValue('numberInput', existingContract.number)
+    await harnesses.router.component.expectInputValue('conditionsInput', existingContract.conditions)
+    await harnesses.router.component.expectButtonEnabled('saveContractButton', true)
 
     await harnesses.router.navigateByUrl(`/contract?contractId=${anotherExistingContract.id}`)
 
-    expect(await harnesses.router.component.inputValue('numberInput')).toBe(anotherExistingContract.number)
-    expect(await harnesses.router.component.inputValue('conditionsInput')).toBe(anotherExistingContract.conditions)
-    expect(await harnesses.router.component.buttonEnabled('saveContractButton')).toBe(true)
+    await harnesses.router.component.expectInputValue('numberInput', anotherExistingContract.number)
+    await harnesses.router.component.expectInputValue('conditionsInput', anotherExistingContract.conditions)
+    await harnesses.router.component.expectButtonEnabled('saveContractButton', true)
   })
 
   it('edit - form is cleared when switching to add mode', async () => {
@@ -265,15 +265,15 @@ describe('ContractComponent', () => {
     } = await initComponent()
     await harnesses.router.navigateByUrl(`/contract?contractId=${existingContract.id}`)
 
-    expect(await harnesses.router.component.inputValue('numberInput')).toBe(existingContract.number)
-    expect(await harnesses.router.component.inputValue('conditionsInput')).toBe(existingContract.conditions)
-    expect(await harnesses.router.component.buttonEnabled('saveContractButton')).toBe(true)
+    await harnesses.router.component.expectInputValue('numberInput', existingContract.number)
+    await harnesses.router.component.expectInputValue('conditionsInput', existingContract.conditions)
+    await harnesses.router.component.expectButtonEnabled('saveContractButton', true)
 
     await harnesses.router.navigateByUrl(`/contract`)
 
-    expect(await harnesses.router.component.inputValue('numberInput')).toBe('')
-    expect(await harnesses.router.component.inputValue('conditionsInput')).toBe('')
-    expect(await harnesses.router.component.buttonEnabled('saveContractButton')).toBe(false)
+    await harnesses.router.component.expectInputValue('numberInput', '')
+    await harnesses.router.component.expectInputValue('conditionsInput', '')
+    await harnesses.router.component.expectButtonEnabled('saveContractButton', false)
   })
 
   it('edit - form is populated when switching from add mode', async () => {
@@ -283,15 +283,15 @@ describe('ContractComponent', () => {
 
     await harnesses.router.navigateByUrl(`/contract`)
 
-    expect(await harnesses.router.component.inputValue('numberInput')).toBe('')
-    expect(await harnesses.router.component.inputValue('conditionsInput')).toBe('')
-    expect(await harnesses.router.component.buttonEnabled('saveContractButton')).toBe(false)
+    await harnesses.router.component.expectInputValue('numberInput', '')
+    await harnesses.router.component.expectInputValue('conditionsInput', '')
+    await harnesses.router.component.expectButtonEnabled('saveContractButton', false)
 
     await harnesses.router.navigateByUrl(`/contract?contractId=${existingContract.id}`)
 
-    expect(await harnesses.router.component.inputValue('numberInput')).toBe(existingContract.number)
-    expect(await harnesses.router.component.inputValue('conditionsInput')).toBe(existingContract.conditions)
-    expect(await harnesses.router.component.buttonEnabled('saveContractButton')).toBe(true)
+    await harnesses.router.component.expectInputValue('numberInput', existingContract.number)
+    await harnesses.router.component.expectInputValue('conditionsInput', existingContract.conditions)
+    await harnesses.router.component.expectButtonEnabled('saveContractButton', true)
   })
 
   it('edit - form remains empty in case of data fetch error', async () => {
@@ -302,9 +302,9 @@ describe('ContractComponent', () => {
 
     await harnesses.router.navigateByUrl(`/contract?contractId=${existingContract.id}`)
     await expectAsync(harnesses.router.component.messageBoxPresent(MessageType.ERROR)).toBeResolvedTo(true)
-    expect(await harnesses.router.component.inputValue('numberInput')).toBe('')
-    expect(await harnesses.router.component.inputValue('conditionsInput')).toBe('')
-    expect(await harnesses.router.component.buttonEnabled('saveContractButton')).toBe(false)
+    await harnesses.router.component.expectInputValue('numberInput', '')
+    await harnesses.router.component.expectInputValue('conditionsInput', '')
+    await harnesses.router.component.expectButtonEnabled('saveContractButton', false)
   })
 
   it('edit - form populated after data fetch error on param change', async () => {
@@ -316,9 +316,9 @@ describe('ContractComponent', () => {
     await harnesses.router.navigateByUrl(`/contract?contractId=${existingContract.id}`)
     await harnesses.router.navigateByUrl(`/contract?contractId=${anotherExistingContract.id}`)
 
-    expect(await harnesses.router.component.inputValue('numberInput')).toBe(anotherExistingContract.number)
-    expect(await harnesses.router.component.inputValue('conditionsInput')).toBe(anotherExistingContract.conditions)
-    expect(await harnesses.router.component.buttonEnabled('saveContractButton')).toBe(true)
+    await harnesses.router.component.expectInputValue('numberInput', anotherExistingContract.number)
+    await harnesses.router.component.expectInputValue('conditionsInput', anotherExistingContract.conditions)
+    await harnesses.router.component.expectButtonEnabled('saveContractButton', true)
   })
 
   it('edit - form data is not changed on data fetch error after param change', async () => {
@@ -330,8 +330,8 @@ describe('ContractComponent', () => {
     await harnesses.router.navigateByUrl(`/contract?contractId=${existingContract.id}`)
     await harnesses.router.navigateByUrl(`/contract?contractId=${anotherExistingContract.id}`)
 
-    expect(await harnesses.router.component.inputValue('numberInput')).toBe(existingContract.number)
-    expect(await harnesses.router.component.inputValue('conditionsInput')).toBe(existingContract.conditions)
-    expect(await harnesses.router.component.buttonEnabled('saveContractButton')).toBe(true)
+    await harnesses.router.component.expectInputValue('numberInput', existingContract.number)
+    await harnesses.router.component.expectInputValue('conditionsInput', existingContract.conditions)
+    await harnesses.router.component.expectButtonEnabled('saveContractButton', true)
   })
 })

--- a/src/app/components/contracts/tests/contracts.component.spec.ts
+++ b/src/app/components/contracts/tests/contracts.component.spec.ts
@@ -97,14 +97,14 @@ describe('ContractsComponent', () => {
 
     expect(await harnesses.router.component.matTableNRows('contractList')).toBe(getVisibleContracts(CONTRACTS).length)
     for (const contract of getVisibleContracts(CONTRACTS)) {
-      expect(await harnesses.router.component.inMatTableRow('contractList', {
+      await harnesses.router.component.inMatTableRow('contractList', {
         number: contract.number
-      }).elementText('contractNumber')).toBe(contract.number)
-      expect(await harnesses.router.component.inMatTableRow('contractList', {
+      }).expectElementText('contractNumber', contract.number)
+      await harnesses.router.component.inMatTableRow('contractList', {
         number: contract.number
-      }).elementText('contractConditions')).toBe(contract.conditions)
+      }).expectElementText('contractConditions', contract.conditions)
     }
-    expect(await harnesses.router.component.elementVisible('noContractsMessage')).toBe(false)
+    await harnesses.router.component.expectElementVisible('noContractsMessage', false)
   })
 
   it('display no contract message if there are no contracts', async () => {
@@ -113,7 +113,7 @@ describe('ContractsComponent', () => {
     } = await initComponent([])
 
     expect(await harnesses.router.component.matTableNRows('contractList')).toBe(0)
-    expect(await harnesses.router.component.elementVisible('noContractsMessage')).toBe(true)
+    await harnesses.router.component.expectElementVisible('noContractsMessage', true)
   })
 
   it('handle backend error during contracts fetch', async () => {
@@ -141,12 +141,12 @@ describe('ContractsComponent', () => {
     await harnesses.router.component.messageBoxClick(MessageActions.CONFIRM)
     expect(await harnesses.router.component.matTableNRows('contractList')).toBe(expectedContracts.length)
     for (const expectedContract of expectedContracts) {
-      expect(await harnesses.router.component.inMatTableRow('contractList', {
+      await harnesses.router.component.inMatTableRow('contractList', {
         number: expectedContract.number
-      }).elementText('contractNumber')).toBe(expectedContract.number)
-      expect(await harnesses.router.component.inMatTableRow('contractList', {
+      }).expectElementText('contractNumber', expectedContract.number)
+      await harnesses.router.component.inMatTableRow('contractList', {
         number: expectedContract.number
-      }).elementText('contractConditions')).toBe(expectedContract.conditions)
+      }).expectElementText('contractConditions', expectedContract.conditions)
     }
   })
 
@@ -164,12 +164,12 @@ describe('ContractsComponent', () => {
     await harnesses.router.component.messageBoxClick(MessageActions.CANCEL)
     expect(await harnesses.router.component.matTableNRows('contractList')).toBe(expectedContracts.length)
     for (const expectedContract of expectedContracts) {
-      expect(await harnesses.router.component.inMatTableRow('contractList', {
+      await harnesses.router.component.inMatTableRow('contractList', {
         number: expectedContract.number
-      }).elementText('contractNumber')).toBe(expectedContract.number)
-      expect(await harnesses.router.component.inMatTableRow('contractList', {
+      }).expectElementText('contractNumber', expectedContract.number)
+      await harnesses.router.component.inMatTableRow('contractList', {
         number: expectedContract.number
-      }).elementText('contractConditions')).toBe(expectedContract.conditions)
+      }).expectElementText('contractConditions', expectedContract.conditions)
     }
   })
 
@@ -217,12 +217,12 @@ describe('ContractsComponent', () => {
 
     await harnesses.router.component.enterValue('contractSearchInput', contractToFind.number)
     expect(await harnesses.router.component.matTableNRows('contractList')).toBe(1)
-    expect(await harnesses.router.component.inMatTableRow('contractList', {
+    await harnesses.router.component.inMatTableRow('contractList', {
       number: contractToFind.number
-    }).elementText('contractNumber')).toBe(contractToFind.number)
-    expect(await harnesses.router.component.inMatTableRow('contractList', {
+    }).expectElementText('contractNumber', contractToFind.number)
+    await harnesses.router.component.inMatTableRow('contractList', {
       number: contractToFind.number
-    }).elementText('contractConditions')).toBe(contractToFind.conditions)
+    }).expectElementText('contractConditions', contractToFind.conditions)
 
     await harnesses.router.component.enterValue('contractSearchInput', '')
     expect(await harnesses.router.component.matTableNRows('contractList')).toBe(getVisibleContracts(CONTRACTS).length)

--- a/src/app/components/home/tests/home.component.spec.ts
+++ b/src/app/components/home/tests/home.component.spec.ts
@@ -41,7 +41,7 @@ describe('HomeComponent', () => {
       harnesses
     } = await initComponent()
 
-    expect(await harnesses.router.component.elementVisible('navToContractsLink')).toBe(true)
+    await harnesses.router.component.expectElementVisible('navToContractsLink', true)
   })
 
   it('FT_Contracts ON - navigate to home page on link click', async () => {
@@ -60,6 +60,6 @@ describe('HomeComponent', () => {
       harnesses
     } = await initComponent()
 
-    expect(await harnesses.router.component.elementVisible('navToContractsLink')).toBe(false)
+    await harnesses.router.component.expectElementVisible('navToContractsLink', false)
   })
 })

--- a/src/app/components/login/test/login.component.spec.ts
+++ b/src/app/components/login/test/login.component.spec.ts
@@ -55,27 +55,27 @@ describe('LoginComponent', () => {
 
     // initial state
     // invalid form: login missing, password missing
-    expect(await harnesses.router.component.buttonEnabled('loginButton')).toBe(false)
+    await harnesses.router.component.expectButtonEnabled('loginButton', false)
 
     // invalid form: login present, password missing
     await harnesses.router.component.enterValue('loginInput', 'my_login')
-    expect(await harnesses.router.component.buttonEnabled('loginButton')).toBe(false)
+    await harnesses.router.component.expectButtonEnabled('loginButton', false)
 
     // valid form: login present, password present
     await harnesses.router.component.enterValue('passwordInput', 'my_password')
-    expect(await harnesses.router.component.buttonEnabled('loginButton')).toBe(true)
+    await harnesses.router.component.expectButtonEnabled('loginButton', true)
 
     // valid form: login present, password present (whitespaces are not ignored for password)
     await harnesses.router.component.enterValue('passwordInput', ' ')
-    expect(await harnesses.router.component.buttonEnabled('loginButton')).toBe(true)
+    await harnesses.router.component.expectButtonEnabled('loginButton', true)
 
     // invalid form: login missing, password present
     await harnesses.router.component.enterValue('loginInput', '')
-    expect(await harnesses.router.component.buttonEnabled('loginButton')).toBe(false)
+    await harnesses.router.component.expectButtonEnabled('loginButton', false)
 
     // invalid form: login missing, password present (whitespaces are ignored for login)
     await harnesses.router.component.enterValue('loginInput', ' ')
-    expect(await harnesses.router.component.buttonEnabled('loginButton')).toBe(false)
+    await harnesses.router.component.expectButtonEnabled('loginButton', false)
   })
 
   it('display/hide error message based on login validity', async () => {
@@ -84,21 +84,21 @@ describe('LoginComponent', () => {
     } = await initComponent()
 
     // initial state: no validation done
-    expect(await harnesses.router.component.elementVisible('loginErrorEmpty')).toBe(false)
+    await harnesses.router.component.expectElementVisible('loginErrorEmpty', false)
 
     // validation is not triggered until blur
     await harnesses.router.component.enterValue('loginInput', '', false)
-    expect(await harnesses.router.component.elementVisible('loginErrorEmpty')).toBe(false)
+    await harnesses.router.component.expectElementVisible('loginErrorEmpty', false)
 
     await harnesses.router.component.enterValue('loginInput', '')
-    expect(await harnesses.router.component.elementVisible('loginErrorEmpty')).toBe(true)
+    await harnesses.router.component.expectElementVisible('loginErrorEmpty', true)
 
     await harnesses.router.component.enterValue('loginInput', 'my_login')
-    expect(await harnesses.router.component.elementVisible('loginErrorEmpty')).toBe(false)
+    await harnesses.router.component.expectElementVisible('loginErrorEmpty', false)
 
     // whitespaces are ignored
     await harnesses.router.component.enterValue('loginInput', ' ')
-    expect(await harnesses.router.component.elementVisible('loginErrorEmpty')).toBe(true)
+    await harnesses.router.component.expectElementVisible('loginErrorEmpty', true)
   })
 
   it('display/hide error message based on password validity', async () => {
@@ -107,21 +107,21 @@ describe('LoginComponent', () => {
     } = await initComponent()
 
     // initial state: no validation done
-    expect(await harnesses.router.component.elementVisible('passwordErrorEmpty')).toBe(false)
+    await harnesses.router.component.expectElementVisible('passwordErrorEmpty', false)
 
     // validation is not triggered until blur
     await harnesses.router.component.enterValue('passwordInput', '', false)
-    expect(await harnesses.router.component.elementVisible('passwordErrorEmpty')).toBe(false)
+    await harnesses.router.component.expectElementVisible('passwordErrorEmpty', false)
 
     await harnesses.router.component.enterValue('passwordInput', '')
-    expect(await harnesses.router.component.elementVisible('passwordErrorEmpty')).toBe(true)
+    await harnesses.router.component.expectElementVisible('passwordErrorEmpty', true)
 
     await harnesses.router.component.enterValue('passwordInput', 'my_password')
-    expect(await harnesses.router.component.elementVisible('passwordErrorEmpty')).toBe(false)
+    await harnesses.router.component.expectElementVisible('passwordErrorEmpty', false)
 
     // whitespaces are not ignored
     await harnesses.router.component.enterValue('passwordInput', ' ')
-    expect(await harnesses.router.component.elementVisible('passwordErrorEmpty')).toBe(false)
+    await harnesses.router.component.expectElementVisible('passwordErrorEmpty', false)
   })
 
   it('display error message in case of invalid credentials', async () => {
@@ -129,12 +129,12 @@ describe('LoginComponent', () => {
       harnesses
     } = await initComponent()
 
-    expect(await harnesses.router.component.elementVisible('incorrectCreds')).toBe(false)
+    await harnesses.router.component.expectElementVisible('incorrectCreds', false)
 
     await harnesses.router.component.enterValue('loginInput', `${VALID_CREDS.login}_invalid`)
     await harnesses.router.component.enterValue('passwordInput', VALID_CREDS.password)
     await harnesses.router.component.clickElement('loginButton')
-    expect(await harnesses.router.component.elementVisible('incorrectCreds')).toBe(true)
+    await harnesses.router.component.expectElementVisible('incorrectCreds', true)
   })
 
   it('navigate to home on successful login', async () => {
@@ -167,14 +167,14 @@ describe('LoginComponent', () => {
 
     // initial state
     expect(await harnesses.router.component.inputType('passwordInput')).toBe('password')
-    expect(await harnesses.router.component.elementText('togglePasswordButtonIcon')).toBe('visibility_off')
+    await harnesses.router.component.expectElementText('togglePasswordButtonIcon', 'visibility_off')
 
     await harnesses.router.component.clickElement('togglePasswordButton')
     expect(await harnesses.router.component.inputType('passwordInput')).toBe('text')
-    expect(await harnesses.router.component.elementText('togglePasswordButtonIcon')).toBe('visibility')
+    await harnesses.router.component.expectElementText('togglePasswordButtonIcon', 'visibility')
 
     await harnesses.router.component.clickElement('togglePasswordButton')
     expect(await harnesses.router.component.inputType('passwordInput')).toBe('password')
-    expect(await harnesses.router.component.elementText('togglePasswordButtonIcon')).toBe('visibility_off')
+    await harnesses.router.component.expectElementText('togglePasswordButtonIcon', 'visibility_off')
   })
 })

--- a/src/app/components/not-found/tests/not-found.component.spec.ts
+++ b/src/app/components/not-found/tests/not-found.component.spec.ts
@@ -22,6 +22,6 @@ describe('NotFoundComponent', () => {
       harnesses
     } = await initComponent()
 
-    expect(await harnesses.router.component.elementVisible('notFoundMessage')).toBe(true)
+    await harnesses.router.component.expectElementVisible('notFoundMessage', true)
   })
 })

--- a/src/app/services/message-box/message-box.service.spec.ts
+++ b/src/app/services/message-box/message-box.service.spec.ts
@@ -33,16 +33,16 @@ describe('MessageBoxService', () => {
     service.error(errorMessage)
     const errorMessageHarness = await harnesses.router.component.matDialogHarness('errorMessageBox', MessageHarness)
 
-    await expectAsync(errorMessageHarness.elementHasClass('messageToolbar', 'error')).toBeResolvedTo(true)
-    await expectAsync(errorMessageHarness.elementText('messageIcon')).toBeResolvedTo('report_problem')
-    await expectAsync(errorMessageHarness.elementText('messageTitle')).toBeResolvedTo('Error')
-    await expectAsync(errorMessageHarness.elementText('message')).toBeResolvedTo(errorMessage)
+    await errorMessageHarness.expectElementClass('messageToolbar', 'error', true)
+    await errorMessageHarness.expectElementText('messageIcon', 'report_problem')
+    await errorMessageHarness.expectElementText('messageTitle', 'Error')
+    await errorMessageHarness.expectElementText('message', errorMessage)
 
     await expectAsync(errorMessageHarness.elementChildCount('messageActions')).toBeResolvedTo(1)
 
-    await expectAsync(errorMessageHarness.elementText('closeButton')).toBeResolvedTo('Close')
-    await expectAsync(errorMessageHarness.elementHasClass('closeButton', 'error')).toBeResolvedTo(true)
-    await expectAsync(errorMessageHarness.elementHasClass('closeButton', 'mat-mdc-raised-button')).toBeResolvedTo(true)
+    await errorMessageHarness.expectElementText('closeButton', 'Close')
+    await errorMessageHarness.expectElementClass('closeButton', 'error', true)
+    await errorMessageHarness.expectElementClass('closeButton', 'mat-mdc-raised-button', true)
   })
 
   it('error close test', async () => {
@@ -67,20 +67,20 @@ describe('MessageBoxService', () => {
     service.confirm(confirmMessage)
     const confirmMessageHarness = await harnesses.router.component.matDialogHarness('confirmMessageBox', MessageHarness)
 
-    await expectAsync(confirmMessageHarness.elementHasClass('messageToolbar', 'confirm')).toBeResolvedTo(true)
-    await expectAsync(confirmMessageHarness.elementText('messageIcon')).toBeResolvedTo('help_outline')
-    await expectAsync(confirmMessageHarness.elementText('messageTitle')).toBeResolvedTo('Please, confirm')
-    await expectAsync(confirmMessageHarness.elementText('message')).toBeResolvedTo(confirmMessage)
+    await confirmMessageHarness.expectElementClass('messageToolbar', 'confirm', true)
+    await confirmMessageHarness.expectElementText('messageIcon', 'help_outline')
+    await confirmMessageHarness.expectElementText('messageTitle', 'Please, confirm')
+    await confirmMessageHarness.expectElementText('message', confirmMessage)
 
     await expectAsync(confirmMessageHarness.elementChildCount('messageActions')).toBeResolvedTo(2)
 
-    await expectAsync(confirmMessageHarness.elementText('cancelButton')).toBeResolvedTo('Cancel')
-    await expectAsync(confirmMessageHarness.elementHasClass('cancelButton', 'confirm')).toBeResolvedTo(false)
-    await expectAsync(confirmMessageHarness.elementHasClass('cancelButton', 'mat-mdc-button')).toBeResolvedTo(true)
+    await confirmMessageHarness.expectElementText('cancelButton', 'Cancel')
+    await confirmMessageHarness.expectElementClass('cancelButton', 'confirm', false)
+    await confirmMessageHarness.expectElementClass('cancelButton', 'mat-mdc-button', true)
 
-    await expectAsync(confirmMessageHarness.elementText('confirmButton')).toBeResolvedTo('Confirm')
-    await expectAsync(confirmMessageHarness.elementHasClass('confirmButton', 'confirm')).toBeResolvedTo(true)
-    await expectAsync(confirmMessageHarness.elementHasClass('confirmButton', 'mat-mdc-raised-button')).toBeResolvedTo(true)
+    await confirmMessageHarness.expectElementText('confirmButton', 'Confirm')
+    await confirmMessageHarness.expectElementClass('confirmButton', 'confirm', true)
+    await confirmMessageHarness.expectElementClass('confirmButton', 'mat-mdc-raised-button', true)
   })
 
   it('confirm confirm/cancel test', async () => {

--- a/src/app/tests/app.component.spec.ts
+++ b/src/app/tests/app.component.spec.ts
@@ -81,13 +81,13 @@ describe('AppComponent', () => {
       harnesses
     } = await initComponent()
 
-    expect(await harnesses.router.component.elementVisible('appHeader')).toBe(true)
+    await harnesses.router.component.expectElementVisible('appHeader', true)
 
     isAuthMock.next(false)
-    expect(await harnesses.router.component.elementVisible('appHeader')).toBe(false)
+    await harnesses.router.component.expectElementVisible('appHeader', false)
 
     isAuthMock.next(true)
-    expect(await harnesses.router.component.elementVisible('appHeader')).toBe(true)
+    await harnesses.router.component.expectElementVisible('appHeader', true)
   })
 
   it('display go home link on non-home page only', async () => {
@@ -96,13 +96,13 @@ describe('AppComponent', () => {
     } = await initComponent()
 
     await harnesses.router.navigateByUrl('/non-home')
-    expect(await harnesses.router.component.elementVisible('navToHomeLink')).toBe(true)
+    await harnesses.router.component.expectElementVisible('navToHomeLink', true)
 
     await harnesses.router.navigateByUrl('/home')
-    expect(await harnesses.router.component.elementVisible('navToHomeLink')).toBe(false)
+    await harnesses.router.component.expectElementVisible('navToHomeLink', false)
 
     await harnesses.router.navigateByUrl('/home/subhome')
-    expect(await harnesses.router.component.elementVisible('navToHomeLink')).toBe(true)
+    await harnesses.router.component.expectElementVisible('navToHomeLink', true)
   })
 
   it('navigate to home page on link click', async () => {
@@ -120,13 +120,13 @@ describe('AppComponent', () => {
     } = await initComponent()
 
     // initial language (see karma.conf.js)
-    await expectAsync(harnesses.router.component.elementText('activeLanguageText')).toBeResolvedTo('en')
+    await harnesses.router.component.expectElementText('activeLanguageText', 'en')
     await expectAsync(harnesses.router.component.matButtonText('logoutButton')).toBeResolvedTo('Logout')
 
     await harnesses.router.component.clickElement('languageContainer')
     await harnesses.router.component.selectMatMenuItem('ru')
 
-    await expectAsync(harnesses.router.component.elementText('activeLanguageText')).toBeResolvedTo('ru')
+    await harnesses.router.component.expectElementText('activeLanguageText', 'ru')
     await expectAsync(harnesses.router.component.matButtonText('logoutButton')).toBeResolvedTo('Выйти')
   })
 })

--- a/src/app/tests/foundation/tests/test.component.spec.ts
+++ b/src/app/tests/foundation/tests/test.component.spec.ts
@@ -95,32 +95,32 @@ describe('Base harnesses', () => {
     }
   })
 
-  it('buttonEnabled', async () => {
+  it('expectButtonEnabled', async () => {
     await expectAsync(baseHarness.elementPresent('enabled-button', 'button')).toBeResolvedTo(true)
-    await expectAsync(baseHarness.buttonEnabled('enabled-button')).toBeResolvedTo(true)
+    await baseHarness.expectButtonEnabled('enabled-button', true)
 
     await expectAsync(baseHarness.elementPresent('disabled-button', 'button')).toBeResolvedTo(true)
-    await expectAsync(baseHarness.buttonEnabled('disabled-button')).toBeResolvedTo(false)
+    await baseHarness.expectButtonEnabled('disabled-button', false)
 
     await expectAsync(baseHarness.elementPresent('non-existent-button', 'button')).toBeResolvedTo(false)
-    await expectAsync(baseHarness.buttonEnabled('non-existent-button')).toBeRejected()
+    await expectAsync(baseHarness.expectButtonEnabled('non-existent-button', true)).toBeRejected()
   })
 
-  it('inputValue', async () => {
+  it('expctInputValue', async () => {
     const tags = [
       'input',
       'textarea'
     ]
     for (const tag of tags) {
       await expectAsync(baseHarness.elementPresent(`${tag}-value`, tag)).toBeResolvedTo(true)
-      await expectAsync(baseHarness.inputValue(`${tag}-value`)).toBeResolvedTo(`some ${tag} value`)
+      await baseHarness.expectInputValue(`${tag}-value`, `some ${tag} value`)
 
       await expectAsync(baseHarness.elementPresent(`non-existent-${tag}-value`, tag)).toBeResolvedTo(false)
-      await expectAsync(baseHarness.buttonEnabled(`non-existent-${tag}-value`)).toBeRejected()
+      await expectAsync(baseHarness.expectInputValue(`non-existent-${tag}-value`, `some ${tag} value`)).toBeRejected()
     }
   })
 
-  it('elementVisible', async () => {
+  it('expectElementVisible', async () => {
     const tags = [
       'h1',
       'p',
@@ -134,38 +134,38 @@ describe('Base harnesses', () => {
     const tagsNotSupportingHidden = ['mat-card']
     for (const tag of tags) {
       await expectAsync(baseHarness.elementPresent(`${tag}-element-visible`, tag)).toBeResolvedTo(true)
-      await expectAsync(baseHarness.elementVisible(`${tag}-element-visible`)).toBeResolvedTo(true)
+      await baseHarness.expectElementVisible(`${tag}-element-visible`, true)
 
       await expectAsync(baseHarness.elementPresent(`${tag}-element-invisible-if`, tag)).toBeResolvedTo(false)
-      await expectAsync(baseHarness.elementVisible(`${tag}-element-invisible-if`)).toBeResolvedTo(false)
+      await baseHarness.expectElementVisible(`${tag}-element-invisible-if`, false)
 
       if (!tagsNotSupportingHidden.includes(tag)) {
         await expectAsync(baseHarness.elementPresent(`${tag}-element-hidden`, tag)).toBeResolvedTo(true)
-        await expectAsync(baseHarness.elementVisible(`${tag}-element-hidden`)).toBeResolvedTo(false)
+        await baseHarness.expectElementVisible(`${tag}-element-hidden`, false)
       }
       else {
         await expectAsync(baseHarness.elementPresent(`${tag}-element-hidden`, tag)).toBeResolvedTo(true)
-        await expectAsync(baseHarness.elementVisible(`${tag}-element-hidden`)).toBeResolvedTo(true)
+        await baseHarness.expectElementVisible(`${tag}-element-hidden`, true)
       }
 
       await expectAsync(baseHarness.elementPresent(`${tag}-element-style-display-none`, tag)).toBeResolvedTo(true)
-      await expectAsync(baseHarness.elementVisible(`${tag}-element-style-display-none`)).toBeResolvedTo(false)
+      await baseHarness.expectElementVisible(`${tag}-element-style-display-none`, false)
 
       await expectAsync(baseHarness.elementPresent(`${tag}-element-style-visibility-hidden`, tag)).toBeResolvedTo(true)
-      await expectAsync(baseHarness.elementVisible(`${tag}-element-style-visibility-hidden`)).toBeResolvedTo(false)
+      await baseHarness.expectElementVisible(`${tag}-element-style-visibility-hidden`, false)
 
       await expectAsync(baseHarness.elementPresent(`${tag}-element-class-display-none`, tag)).toBeResolvedTo(true)
-      await expectAsync(baseHarness.elementVisible(`${tag}-element-class-display-none`)).toBeResolvedTo(false)
+      await baseHarness.expectElementVisible(`${tag}-element-class-display-none`, false)
 
       await expectAsync(baseHarness.elementPresent(`${tag}-element-class-visibility-hidden`, tag)).toBeResolvedTo(true)
-      await expectAsync(baseHarness.elementVisible(`${tag}-element-class-visibility-hidden`)).toBeResolvedTo(false)
+      await baseHarness.expectElementVisible(`${tag}-element-class-visibility-hidden`, false)
 
       await expectAsync(baseHarness.elementPresent(`${tag}-element-non-existent`, tag)).toBeResolvedTo(false)
-      await expectAsync(baseHarness.elementVisible(`${tag}-element-non-existent`)).toBeResolvedTo(false)
+      await baseHarness.expectElementVisible(`${tag}-element-non-existent`, false)
     }
   })
 
-  it('elementText', async () => {
+  it('expectElementText', async () => {
     const tags = [
       'h1',
       'h4',
@@ -179,35 +179,37 @@ describe('Base harnesses', () => {
     for (const tag of tags) {
       const elementId = `${tag}-element-text`
       await expectAsync(baseHarness.elementPresent(elementId, tag)).toBeResolvedTo(true)
-      await expectAsync(baseHarness.elementText(elementId)).toBeResolvedTo(`${tag} text`)
+      await baseHarness.expectElementText(elementId, `${tag} text`)
+
+      await expectAsync(baseHarness.expectElementText(elementId, `${tag} text other`)).toBeRejected()
 
       await expectAsync(baseHarness.elementPresent(`${elementId}-non-existent`, tag)).toBeResolvedTo(false)
-      await expectAsync(baseHarness.elementText(`${elementId}-non-existent`)).toBeRejected()
+      await expectAsync(baseHarness.expectElementText(`${elementId}-non-existent`, `${tag} text`)).toBeRejected()
 
       // elements in wrapper found, not global ones
       await expectAsync(baseHarness.inElement('text-element-wrapper').elementPresent(elementId, tag)).toBeResolvedTo(true)
-      await expectAsync(baseHarness.inElement('text-element-wrapper').elementText(elementId)).toBeResolvedTo(`${tag} text in wrapper`)
+      await baseHarness.inElement('text-element-wrapper').expectElementText(elementId, `${tag} text in wrapper`)
 
       // elements in wrapper are looked up and not found, global elements are ignored
       await expectAsync(baseHarness.inElement('text-element-wrapper-non-existent-elements').elementPresent(elementId, tag)).toBeResolvedTo(false)
-      await expectAsync(baseHarness.inElement('text-element-wrapper-non-existent-elements').elementText(elementId)).toBeRejected()
+      await expectAsync(baseHarness.inElement('text-element-wrapper-non-existent-elements').expectElementText(elementId, `${tag} text in wrapper`)).toBeRejected()
     }
   })
 
-  it('elementHasClass', async () => {
+  it('expectElementClass', async () => {
     const tags = [
       'button',
       'mat-toolbar'
     ]
     for (const tag of tags) {
       await expectAsync(baseHarness.elementPresent(`${tag}-element-class`, tag)).toBeResolvedTo(true)
-      await expectAsync(baseHarness.elementHasClass(`${tag}-element-class`, `testClass-${tag}`)).toBeResolvedTo(true)
+      await baseHarness.expectElementClass(`${tag}-element-class`, `testClass-${tag}`, true)
 
       await expectAsync(baseHarness.elementPresent(`${tag}-element-class`, tag)).toBeResolvedTo(true)
-      await expectAsync(baseHarness.elementHasClass(`${tag}-element-class`, `testClass-${tag}-other`)).toBeResolvedTo(false)
+      await baseHarness.expectElementClass(`${tag}-element-class`, `testClass-${tag}-other`, false)
 
       await expectAsync(baseHarness.elementPresent(`${tag}-element-class-non-existent`, tag)).toBeResolvedTo(false)
-      await expectAsync(baseHarness.elementHasClass(`${tag}-element-class-non-existent`, `testClass-${tag}`)).toBeRejected()
+      await expectAsync(baseHarness.expectElementClass(`${tag}-element-class-non-existent`, `testClass-${tag}`, true)).toBeRejected()
     }
   })
 


### PR DESCRIPTION
Jasmine 'expect' does not provide polling and polling is required in async operation environments without built-in sync (e.g. e2e tests against real apps).
This is why we switch from 'expect' assertions to custom assertions utilizing polling for assertion execution;
Migrate several assertion methods;